### PR TITLE
feat(backend): JWT stateless authentication (FR-03)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/RecruitApplication.java
+++ b/backend/src/main/java/com/eaa/recruit/RecruitApplication.java
@@ -2,8 +2,10 @@ package com.eaa.recruit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties
 public class RecruitApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/eaa/recruit/config/SecurityConfig.java
+++ b/backend/src/main/java/com/eaa/recruit/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.eaa.recruit.config;
 
+import com.eaa.recruit.security.JwtAccessDeniedHandler;
+import com.eaa.recruit.security.JwtAuthEntryPoint;
+import com.eaa.recruit.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -10,22 +13,41 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthEntryPoint jwtAuthEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          JwtAuthEntryPoint jwtAuthEntryPoint,
+                          JwtAccessDeniedHandler jwtAccessDeniedHandler) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.jwtAuthEntryPoint = jwtAuthEntryPoint;
+        this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint(jwtAuthEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+            )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 .requestMatchers("/api/v1/auth/**").permitAll()
                 .anyRequest().authenticated()
-            );
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 

--- a/backend/src/main/java/com/eaa/recruit/security/AuthenticatedUser.java
+++ b/backend/src/main/java/com/eaa/recruit/security/AuthenticatedUser.java
@@ -1,0 +1,8 @@
+package com.eaa.recruit.security;
+
+/**
+ * Immutable principal stored in the SecurityContext after JWT validation.
+ * Carries only the claims extracted from the token — no DB lookup needed per request.
+ */
+public record AuthenticatedUser(Long id, String email, String role) {
+}

--- a/backend/src/main/java/com/eaa/recruit/security/JwtAccessDeniedHandler.java
+++ b/backend/src/main/java/com/eaa/recruit/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.eaa.recruit.security;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), ApiResponse.error("Access denied"));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/security/JwtAuthEntryPoint.java
+++ b/backend/src/main/java/com/eaa/recruit/security/JwtAuthEntryPoint.java
@@ -1,0 +1,32 @@
+package com.eaa.recruit.security;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), ApiResponse.error("Unauthorized"));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/eaa/recruit/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.eaa.recruit.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            String email  = jwtTokenProvider.extractEmail(token);
+            Long   userId = jwtTokenProvider.extractUserId(token);
+            String role   = jwtTokenProvider.extractRole(token);
+
+            AuthenticatedUser principal = new AuthenticatedUser(userId, email, role);
+            List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+
+            UsernamePasswordAuthenticationToken auth =
+                    new UsernamePasswordAuthenticationToken(principal, null, authorities);
+            auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith(BEARER_PREFIX)) {
+            return bearer.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/security/JwtProperties.java
+++ b/backend/src/main/java/com/eaa/recruit/security/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.eaa.recruit.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String secret;
+    private long expirationMs;
+
+    public String getSecret() { return secret; }
+    public void setSecret(String secret) { this.secret = secret; }
+
+    public long getExpirationMs() { return expirationMs; }
+    public void setExpirationMs(long expirationMs) { this.expirationMs = expirationMs; }
+}

--- a/backend/src/main/java/com/eaa/recruit/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/eaa/recruit/security/JwtTokenProvider.java
@@ -1,0 +1,80 @@
+package com.eaa.recruit.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtTokenProvider.class);
+
+    private static final String CLAIM_USER_ID = "userId";
+    private static final String CLAIM_ROLE    = "role";
+
+    private final JwtProperties props;
+    private final SecretKey signingKey;
+
+    public JwtTokenProvider(JwtProperties props) {
+        this.props = props;
+        this.signingKey = Keys.hmacShaKeyFor(props.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(Long userId, String role, String email) {
+        Date now    = new Date();
+        Date expiry = new Date(now.getTime() + props.getExpirationMs());
+
+        return Jwts.builder()
+                .subject(email)
+                .claim(CLAIM_USER_ID, userId)
+                .claim(CLAIM_ROLE, role)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(signingKey)
+                .compact();
+    }
+
+    public Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public String extractEmail(String token) {
+        return extractAllClaims(token).getSubject();
+    }
+
+    public Long extractUserId(String token) {
+        return extractAllClaims(token).get(CLAIM_USER_ID, Long.class);
+    }
+
+    public String extractRole(String token) {
+        return extractAllClaims(token).get(CLAIM_ROLE, String.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            extractAllClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.debug("JWT expired: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.debug("JWT unsupported: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.debug("JWT malformed: {}", e.getMessage());
+        } catch (SecurityException e) {
+            log.debug("JWT signature invalid: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.debug("JWT claims empty: {}", e.getMessage());
+        }
+        return false;
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/security/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/eaa/recruit/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,75 @@
+package com.eaa.recruit.security;
+
+import com.eaa.recruit.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class,
+         JwtTokenProvider.class, JwtProperties.class,
+         JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class JwtAuthenticationFilterTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtTokenProvider tokenProvider;
+
+    // Minimal protected controller just for this test slice
+    @RestController
+    static class ProbeController {
+        @GetMapping("/api/v1/probe")
+        String probe() { return "ok"; }
+
+        @GetMapping("/actuator/health")
+        String health() { return "UP"; }
+    }
+
+    @Test
+    void noTokenReturns401() throws Exception {
+        mockMvc.perform(get("/api/v1/probe"))
+               .andExpect(status().isUnauthorized())
+               .andExpect(jsonPath("$.status").value("error"));
+    }
+
+    @Test
+    void validTokenReturns200() throws Exception {
+        String token = tokenProvider.generateToken(1L, "CANDIDATE", "alice@example.com");
+
+        mockMvc.perform(get("/api/v1/probe")
+                        .header("Authorization", "Bearer " + token))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    void expiredTokenReturns401() throws Exception {
+        JwtProperties shortProps = new JwtProperties();
+        shortProps.setSecret("test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes");
+        shortProps.setExpirationMs(-1L);
+        JwtTokenProvider shortProvider = new JwtTokenProvider(shortProps);
+        String expired = shortProvider.generateToken(1L, "CANDIDATE", "x@x.com");
+
+        mockMvc.perform(get("/api/v1/probe")
+                        .header("Authorization", "Bearer " + expired))
+               .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void publicEndpointNoTokenReturns200() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+               .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/security/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/eaa/recruit/security/JwtTokenProviderTest.java
@@ -1,0 +1,58 @@
+package com.eaa.recruit.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties();
+        props.setSecret("test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes");
+        props.setExpirationMs(3_600_000L); // 1 hour
+        provider = new JwtTokenProvider(props);
+    }
+
+    @Test
+    void generateAndValidate() {
+        String token = provider.generateToken(42L, "CANDIDATE", "alice@example.com");
+        assertThat(provider.validateToken(token)).isTrue();
+    }
+
+    @Test
+    void claimsRoundTrip() {
+        String token = provider.generateToken(7L, "RECRUITER", "bob@example.com");
+
+        assertThat(provider.extractEmail(token)).isEqualTo("bob@example.com");
+        assertThat(provider.extractUserId(token)).isEqualTo(7L);
+        assertThat(provider.extractRole(token)).isEqualTo("RECRUITER");
+    }
+
+    @Test
+    void expiredTokenIsRejected() {
+        JwtProperties shortProps = new JwtProperties();
+        shortProps.setSecret("test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes");
+        shortProps.setExpirationMs(-1L); // already expired
+        JwtTokenProvider shortProvider = new JwtTokenProvider(shortProps);
+
+        String token = shortProvider.generateToken(1L, "CANDIDATE", "x@x.com");
+        assertThat(shortProvider.validateToken(token)).isFalse();
+    }
+
+    @Test
+    void tamperedTokenIsRejected() {
+        String token = provider.generateToken(1L, "CANDIDATE", "x@x.com");
+        String tampered = token.substring(0, token.length() - 4) + "XXXX";
+        assertThat(provider.validateToken(tampered)).isFalse();
+    }
+
+    @Test
+    void emptyTokenIsRejected() {
+        assertThat(provider.validateToken("")).isFalse();
+        assertThat(provider.validateToken("not.a.jwt")).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- `JwtTokenProvider` — generates signed HS256 tokens with `userId`, `role`, `email` (subject) claims; validates expiry/signature/structure
- `JwtAuthenticationFilter` (`OncePerRequestFilter`) — extracts Bearer token, validates, populates `SecurityContext` with `AuthenticatedUser` principal
- `AuthenticatedUser` record — immutable principal (id, email, role); no DB lookup per request
- `JwtAuthEntryPoint` / `JwtAccessDeniedHandler` — return `ApiResponse` JSON on 401/403 instead of Spring default HTML
- `SecurityConfig` updated — filter wired before `UsernamePasswordAuthenticationFilter`, `STATELESS` session policy confirmed
- `JwtProperties` `@ConfigurationProperties` — secret and expiry fully externalized via `jwt.*` env vars

## Test plan

- [ ] `JwtTokenProviderTest` — generate+validate, claims round-trip, expired token rejected, tampered token rejected, empty/garbage rejected
- [ ] `JwtAuthenticationFilterTest` — no token → 401, valid token → 200, expired token → 401, public endpoint no token → 200

