### PR TITLE
feat(backend): global exception handler and API response wrapper (FR-04)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/dto/ApiResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/ApiResponse.java
@@ -1,24 +1,47 @@
 package com.eaa.recruit.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.time.Instant;
 
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Standard API envelope for all responses.
+ *
+ * Success shape: { status, message, data, timestamp }
+ * Error shape:   { status, message, errors, timestamp }
+ *
+ * Fields are omitted from JSON when null (@JsonInclude.NON_NULL).
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(
         String status,
         String message,
         T data,
+        List<FieldError> errors,
         Instant timestamp
 ) {
+    // ── success factories ────────────────────────────────────────────────────
+
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>("success", null, data, Instant.now());
+        return new ApiResponse<>("success", null, data, null, Instant.now());
     }
 
     public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>("success", message, data, Instant.now());
+        return new ApiResponse<>("success", message, data, null, Instant.now());
     }
 
-    public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>("error", message, null, Instant.now());
+    public static ApiResponse<Void> success(String message) {
+        return new ApiResponse<>("success", message, null, null, Instant.now());
+    }
+
+    // ── error factories ──────────────────────────────────────────────────────
+
+    public static ApiResponse<Void> error(String message) {
+        return new ApiResponse<>("error", message, null, null, Instant.now());
+    }
+
+    public static ApiResponse<Void> error(String message, List<FieldError> errors) {
+        return new ApiResponse<>("error", message, null, errors, Instant.now());
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/dto/FieldError.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/FieldError.java
@@ -1,0 +1,7 @@
+package com.eaa.recruit.dto;
+
+/**
+ * Single field-level validation error returned inside ApiResponse.errors.
+ */
+public record FieldError(String field, String message) {
+}

--- a/backend/src/main/java/com/eaa/recruit/exception/ConflictException.java
+++ b/backend/src/main/java/com/eaa/recruit/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package com.eaa.recruit.exception;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/eaa/recruit/exception/GlobalExceptionHandler.java
@@ -1,19 +1,31 @@
 package com.eaa.recruit.exception;
 
 import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.FieldError;
+import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
-import java.util.stream.Collectors;
+import java.util.List;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    // ── Domain exceptions ────────────────────────────────────────────────────
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleNotFound(ResourceNotFoundException ex) {
@@ -27,30 +39,112 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ex.getMessage()));
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
-        String message = ex.getBindingResult().getFieldErrors().stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining(", "));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(message));
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorized(UnauthorizedException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error(ex.getMessage()));
     }
 
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConflict(ConflictException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(ex.getMessage()));
+    }
+
+    // ── Validation exceptions ────────────────────────────────────────────────
+
+    /**
+     * Handles @Valid / @Validated failures on @RequestBody.
+     * Returns structured list of field-level errors.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex) {
+
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> new FieldError(fe.getField(), fe.getDefaultMessage()))
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("Validation failed", fieldErrors));
+    }
+
+    /**
+     * Handles @Validated failures on @PathVariable / @RequestParam (constraint violations).
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(
+            ConstraintViolationException ex) {
+
+        List<FieldError> fieldErrors = ex.getConstraintViolations().stream()
+                .map(cv -> {
+                    String path = cv.getPropertyPath().toString();
+                    String field = path.contains(".") ? path.substring(path.lastIndexOf('.') + 1) : path;
+                    return new FieldError(field, cv.getMessage());
+                })
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("Validation failed", fieldErrors));
+    }
+
+    // ── Spring MVC / HTTP exceptions ─────────────────────────────────────────
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnreadable(HttpMessageNotReadableException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("Malformed or missing request body"));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingParam(
+            MissingServletRequestParameterException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("Required parameter missing: " + ex.getParameterName()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(
+            MethodArgumentTypeMismatchException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("Invalid value for parameter: " + ex.getName()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(
+            HttpRequestMethodNotSupportedException ex) {
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(ApiResponse.error("HTTP method not supported: " + ex.getMethod()));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoHandler(NoHandlerFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("No resource found at: " + ex.getRequestURL()));
+    }
+
+    // ── Security exceptions ──────────────────────────────────────────────────
+
     @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAuth(AuthenticationException ex) {
+    public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(
+            AuthenticationException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.error("Authentication failed"));
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAccess(AccessDeniedException ex) {
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(AccessDeniedException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(ApiResponse.error("Access denied"));
     }
 
+    // ── Catch-all ────────────────────────────────────────────────────────────
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGeneral(Exception ex) {
+        // Log with full stack trace internally — never expose to client
+        log.error("Unhandled exception: {}", ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("Internal server error"));
+                .body(ApiResponse.error("An unexpected error occurred"));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/eaa/recruit/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.eaa.recruit.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,182 @@
+package com.eaa.recruit.exception;
+
+import com.eaa.recruit.config.SecurityConfig;
+import com.eaa.recruit.security.JwtAccessDeniedHandler;
+import com.eaa.recruit.security.JwtAuthEntryPoint;
+import com.eaa.recruit.security.JwtAuthenticationFilter;
+import com.eaa.recruit.security.JwtProperties;
+import com.eaa.recruit.security.JwtTokenProvider;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.*;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest
+@Import({GlobalExceptionHandler.class, SecurityConfig.class,
+         JwtAuthenticationFilter.class, JwtTokenProvider.class,
+         JwtProperties.class, JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class GlobalExceptionHandlerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    // ── Minimal controllers used only in this test slice ─────────────────────
+
+    record CreateRequest(@NotBlank(message = "name is required")
+                         @Size(min = 2, max = 50, message = "name must be 2-50 chars")
+                         String name,
+                         @NotBlank(message = "email is required") String email) {}
+
+    @RestController
+    @RequestMapping("/test")
+    static class TestController {
+
+        @GetMapping("/not-found")
+        String notFound() { throw new ResourceNotFoundException("Item", 99L); }
+
+        @GetMapping("/business-error")
+        String businessError() { throw new BusinessException("Quota exceeded"); }
+
+        @GetMapping("/unauthorized")
+        String unauthorized() { throw new UnauthorizedException("Token invalid"); }
+
+        @GetMapping("/conflict")
+        String conflict() { throw new ConflictException("Email already registered"); }
+
+        @GetMapping("/server-error")
+        String serverError() { throw new RuntimeException("DB connection lost"); }
+
+        @PostMapping("/validate")
+        String validate(@Valid @RequestBody CreateRequest req) { return "ok"; }
+
+        @GetMapping("/restricted")
+        @org.springframework.security.access.prepost.PreAuthorize("hasRole('ADMIN')")
+        String restricted() { return "admin only"; }
+    }
+
+    // ── 404 ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    void resourceNotFoundReturns404() throws Exception {
+        mockMvc.perform(get("/test/not-found"))
+               .andExpect(status().isNotFound())
+               .andExpect(jsonPath("$.status").value("error"))
+               .andExpect(jsonPath("$.message").value("Item not found with id: 99"))
+               .andExpect(jsonPath("$.timestamp").exists())
+               .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    // ── 400 business ─────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    void businessExceptionReturns400() throws Exception {
+        mockMvc.perform(get("/test/business-error"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.status").value("error"))
+               .andExpect(jsonPath("$.message").value("Quota exceeded"));
+    }
+
+    // ── 401 ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    void unauthorizedExceptionReturns401() throws Exception {
+        mockMvc.perform(get("/test/unauthorized"))
+               .andExpect(status().isUnauthorized())
+               .andExpect(jsonPath("$.status").value("error"));
+    }
+
+    // ── 409 ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    void conflictExceptionReturns409() throws Exception {
+        mockMvc.perform(get("/test/conflict"))
+               .andExpect(status().isConflict())
+               .andExpect(jsonPath("$.status").value("error"))
+               .andExpect(jsonPath("$.message").value("Email already registered"));
+    }
+
+    // ── 500 — no stack trace ─────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    void internalErrorReturns500WithoutStackTrace() throws Exception {
+        mockMvc.perform(get("/test/server-error"))
+               .andExpect(status().isInternalServerError())
+               .andExpect(jsonPath("$.status").value("error"))
+               .andExpect(jsonPath("$.message").value("An unexpected error occurred"))
+               // stack trace must never appear
+               .andExpect(jsonPath("$.trace").doesNotExist())
+               .andExpect(jsonPath("$.errors").doesNotExist());
+    }
+
+    // ── Validation — structured field errors ─────────────────────────────────
+
+    @Test
+    @WithMockUser
+    void validationErrorReturns400WithFieldErrors() throws Exception {
+        String body = """
+                {"name": "", "email": ""}
+                """;
+        mockMvc.perform(post("/test/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.status").value("error"))
+               .andExpect(jsonPath("$.message").value("Validation failed"))
+               .andExpect(jsonPath("$.errors").isArray())
+               .andExpect(jsonPath("$.errors", hasSize(greaterThanOrEqualTo(2))))
+               .andExpect(jsonPath("$.errors[*].field", hasItems("name", "email")))
+               .andExpect(jsonPath("$.errors[*].message").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void malformedJsonReturns400() throws Exception {
+        mockMvc.perform(post("/test/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{bad json"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.status").value("error"))
+               .andExpect(jsonPath("$.message").value("Malformed or missing request body"));
+    }
+
+    // ── 401 unauthenticated ───────────────────────────────────────────────────
+
+    @Test
+    void noTokenReturns401() throws Exception {
+        mockMvc.perform(get("/test/not-found"))
+               .andExpect(status().isUnauthorized())
+               .andExpect(jsonPath("$.status").value("error"));
+    }
+
+    // ── 403 forbidden ────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "CANDIDATE")
+    void insufficientRoleReturns403() throws Exception {
+        mockMvc.perform(get("/test/restricted"))
+               .andExpect(status().isForbidden())
+               .andExpect(jsonPath("$.status").value("error"));
+    }
+}


### PR DESCRIPTION
## Summary

- **`FieldError` record** — `{ field, message }` for per-field validation feedback
- **`ApiResponse<T>` updated** — adds `errors` field; success shape `{ status, message, data, timestamp }`, error shape `{ status, message, errors, timestamp }`; `@JsonInclude(NON_NULL)` keeps null fields out of JSON
- **`GlobalExceptionHandler` rewritten** — full coverage:

| Exception | HTTP |
|---|---|
| `ResourceNotFoundException` | 404 |
| `BusinessException` | 400 |
| `UnauthorizedException` | 401 |
| `ConflictException` | 409 |
| `MethodArgumentNotValidException` | 400 + field errors list |
| `ConstraintViolationException` | 400 + field errors list |
| `HttpMessageNotReadableException` | 400 |
| `MissingServletRequestParameterException` | 400 |
| `MethodArgumentTypeMismatchException` | 400 |
| `HttpRequestMethodNotSupportedException` | 405 |
| `NoHandlerFoundException` | 404 |
| `AuthenticationException` | 401 |
| `AccessDeniedException` | 403 |
| `Exception` (catch-all) | 500 — logs internally, generic message to client |

- **`UnauthorizedException`** and **`ConflictException`** added as domain exception types

## Test plan

- [ ] 404 — `ResourceNotFoundException` → correct message, no `data`
- [ ] 400 — `BusinessException` → message
- [ ] 401 — `UnauthorizedException` → message
- [ ] 409 — `ConflictException` → message
- [ ] 500 — no `trace`, no `errors`, generic message only
- [ ] Validation — `errors[]` array with `field`+`message` per violation
- [ ] Malformed JSON → 400 with safe message
- [ ] No token → 401 JSON (not Spring HTML)
- [ ] Wrong role → 403 JSON

