### PR TITLE
feat(backend): Kafka producer config and event publishing (FR-05)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/config/KafkaConfig.java
+++ b/backend/src/main/java/com/eaa/recruit/config/KafkaConfig.java
@@ -1,0 +1,87 @@
+package com.eaa.recruit.config;
+
+import com.eaa.recruit.messaging.KafkaTopics;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.producer.acks:all}")
+    private String acks;
+
+    @Value("${spring.kafka.producer.retries:3}")
+    private int retries;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        // Strongest durability: wait for all in-sync replicas to ack
+        props.put(ProducerConfig.ACKS_CONFIG, acks);
+        // Retry on transient broker errors
+        props.put(ProducerConfig.RETRIES_CONFIG, retries);
+        props.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 500);
+        // Idempotent producer: exactly-once delivery per session
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        // Include type header so consumers can deserialise without explicit type mapping
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // ── Topic declarations (auto-created on startup if broker allows) ────────
+
+    @Bean
+    public NewTopic cvUploadedTopic() {
+        return TopicBuilder.name(KafkaTopics.CV_UPLOADED)
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic examBatchReadyTopic() {
+        return TopicBuilder.name(KafkaTopics.EXAM_BATCH_READY)
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic examCompletedTopic() {
+        return TopicBuilder.name(KafkaTopics.EXAM_COMPLETED)
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic examSubmittedTopic() {
+        return TopicBuilder.name(KafkaTopics.EXAM_SUBMITTED)
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/messaging/KafkaEventPublisher.java
+++ b/backend/src/main/java/com/eaa/recruit/messaging/KafkaEventPublisher.java
@@ -1,0 +1,62 @@
+package com.eaa.recruit.messaging;
+
+import com.eaa.recruit.messaging.event.CvUploadedEvent;
+import com.eaa.recruit.messaging.event.ExamBatchReadyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class KafkaEventPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaEventPublisher.class);
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public KafkaEventPublisher(KafkaTemplate<String, Object> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    /**
+     * Publishes a CV_UPLOADED event.
+     * Key = applicationId (string) — ensures all events for the same application
+     * land on the same partition, preserving order.
+     */
+    public void publishCvUploaded(CvUploadedEvent event) {
+        String key = String.valueOf(event.applicationId());
+        send(KafkaTopics.CV_UPLOADED, key, event);
+    }
+
+    /**
+     * Publishes an EXAM_BATCH_READY event.
+     * Key = batchId (string).
+     */
+    public void publishExamBatchReady(ExamBatchReadyEvent event) {
+        String key = String.valueOf(event.batchId());
+        send(KafkaTopics.EXAM_BATCH_READY, key, event);
+    }
+
+    // ── Internal send with structured logging ────────────────────────────────
+
+    private void send(String topic, String key, Object payload) {
+        CompletableFuture<SendResult<String, Object>> future =
+                kafkaTemplate.send(topic, key, payload);
+
+        future.whenComplete((result, ex) -> {
+            if (ex != null) {
+                log.error("Failed to publish event to topic='{}' key='{}' payload='{}': {}",
+                        topic, key, payload, ex.getMessage(), ex);
+            } else {
+                log.debug("Published event to topic='{}' partition={} offset={} key='{}'",
+                        topic,
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset(),
+                        key);
+            }
+        });
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/messaging/KafkaTopics.java
+++ b/backend/src/main/java/com/eaa/recruit/messaging/KafkaTopics.java
@@ -1,0 +1,15 @@
+package com.eaa.recruit.messaging;
+
+/**
+ * Central registry of all Kafka topic names.
+ * Use these constants everywhere — never inline topic strings.
+ */
+public final class KafkaTopics {
+
+    private KafkaTopics() {}
+
+    public static final String CV_UPLOADED       = "CV_UPLOADED";
+    public static final String EXAM_BATCH_READY  = "EXAM_BATCH_READY";
+    public static final String EXAM_COMPLETED    = "EXAM_COMPLETED";
+    public static final String EXAM_SUBMITTED    = "EXAM_SUBMITTED";
+}

--- a/backend/src/main/java/com/eaa/recruit/messaging/event/CvUploadedEvent.java
+++ b/backend/src/main/java/com/eaa/recruit/messaging/event/CvUploadedEvent.java
@@ -1,0 +1,21 @@
+package com.eaa.recruit.messaging.event;
+
+import java.time.Instant;
+
+/**
+ * Published to CV_UPLOADED after a candidate's CV is stored.
+ * Consumed by the Python AI service for screening.
+ */
+public record CvUploadedEvent(
+        Long   applicationId,
+        Long   candidateId,
+        Long   jobId,
+        String cvStoragePath,
+        Instant occurredAt
+) {
+    public static CvUploadedEvent of(Long applicationId, Long candidateId,
+                                     Long jobId, String cvStoragePath) {
+        return new CvUploadedEvent(applicationId, candidateId, jobId,
+                                   cvStoragePath, Instant.now());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/messaging/event/ExamBatchReadyEvent.java
+++ b/backend/src/main/java/com/eaa/recruit/messaging/event/ExamBatchReadyEvent.java
@@ -1,0 +1,25 @@
+package com.eaa.recruit.messaging.event;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Published to EXAM_BATCH_READY when a recruiter authorises an exam batch.
+ * Consumed by the Go Exam Engine to initialise concurrent exam sessions.
+ */
+public record ExamBatchReadyEvent(
+        Long        batchId,
+        Long        jobId,
+        List<Long>  candidateIds,
+        Integer     durationMinutes,
+        Instant     scheduledAt,
+        Instant     occurredAt
+) {
+    public static ExamBatchReadyEvent of(Long batchId, Long jobId,
+                                         List<Long> candidateIds,
+                                         Integer durationMinutes,
+                                         Instant scheduledAt) {
+        return new ExamBatchReadyEvent(batchId, jobId, candidateIds,
+                                       durationMinutes, scheduledAt, Instant.now());
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -47,12 +47,20 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: ${KAFKA_PRODUCER_ACKS:all}
+      retries: ${KAFKA_PRODUCER_RETRIES:3}
+      properties:
+        enable.idempotence: true
+        retry.backoff.ms: 500
     consumer:
-      group-id: recruit-backend
+      group-id: ${KAFKA_CONSUMER_GROUP:recruit-backend}
+      auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         spring.json.trusted.packages: "com.eaa.recruit.*"
+    admin:
+      auto-create: true
 
   flyway:
     enabled: true

--- a/backend/src/test/java/com/eaa/recruit/messaging/KafkaEventPublisherTest.java
+++ b/backend/src/test/java/com/eaa/recruit/messaging/KafkaEventPublisherTest.java
@@ -1,0 +1,141 @@
+package com.eaa.recruit.messaging;
+
+import com.eaa.recruit.messaging.event.CvUploadedEvent;
+import com.eaa.recruit.messaging.event.ExamBatchReadyEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext
+@EmbeddedKafka(
+    partitions = 1,
+    topics = {KafkaTopics.CV_UPLOADED, KafkaTopics.EXAM_BATCH_READY},
+    brokerProperties = {
+        "listeners=PLAINTEXT://localhost:${random.int[10000,20000]}",
+        "auto.create.topics.enable=true"
+    }
+)
+class KafkaEventPublisherTest {
+
+    @Autowired KafkaEventPublisher publisher;
+    @Autowired EmbeddedKafkaBroker embeddedKafka;
+
+    private KafkaMessageListenerContainer<String, Object> container;
+    private BlockingQueue<ConsumerRecord<String, Object>> records;
+
+    @BeforeEach
+    void setUp() {
+        records = new LinkedBlockingQueue<>();
+
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(
+                "test-group", "true", embeddedKafka);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class);
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                JsonDeserializer.class);
+        consumerProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.eaa.recruit.*");
+        consumerProps.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, true);
+
+        DefaultKafkaConsumerFactory<String, Object> cf =
+                new DefaultKafkaConsumerFactory<>(consumerProps);
+
+        ContainerProperties containerProps = new ContainerProperties(
+                KafkaTopics.CV_UPLOADED, KafkaTopics.EXAM_BATCH_READY);
+        container = new KafkaMessageListenerContainer<>(cf, containerProps);
+        container.setupMessageListener((MessageListener<String, Object>) records::add);
+        container.start();
+
+        ContainerTestUtils.waitForAssignment(container, embeddedKafka.getPartitionsPerTopic());
+    }
+
+    @AfterEach
+    void tearDown() {
+        container.stop();
+    }
+
+    @Test
+    void publishCvUploaded_messageArrivesOnTopic() throws InterruptedException {
+        CvUploadedEvent event = CvUploadedEvent.of(10L, 5L, 3L, "/storage/cv/10.pdf");
+
+        publisher.publishCvUploaded(event);
+
+        ConsumerRecord<String, Object> received = records.poll(5, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.topic()).isEqualTo(KafkaTopics.CV_UPLOADED);
+        assertThat(received.key()).isEqualTo("10");
+
+        CvUploadedEvent payload = (CvUploadedEvent) received.value();
+        assertThat(payload.applicationId()).isEqualTo(10L);
+        assertThat(payload.candidateId()).isEqualTo(5L);
+        assertThat(payload.jobId()).isEqualTo(3L);
+        assertThat(payload.cvStoragePath()).isEqualTo("/storage/cv/10.pdf");
+        assertThat(payload.occurredAt()).isNotNull();
+    }
+
+    @Test
+    void publishExamBatchReady_messageArrivesOnTopic() throws InterruptedException {
+        ExamBatchReadyEvent event = ExamBatchReadyEvent.of(
+                99L, 7L, List.of(1L, 2L, 3L), 60, Instant.now());
+
+        publisher.publishExamBatchReady(event);
+
+        ConsumerRecord<String, Object> received = records.poll(5, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.topic()).isEqualTo(KafkaTopics.EXAM_BATCH_READY);
+        assertThat(received.key()).isEqualTo("99");
+
+        ExamBatchReadyEvent payload = (ExamBatchReadyEvent) received.value();
+        assertThat(payload.batchId()).isEqualTo(99L);
+        assertThat(payload.jobId()).isEqualTo(7L);
+        assertThat(payload.candidateIds()).containsExactly(1L, 2L, 3L);
+        assertThat(payload.durationMinutes()).isEqualTo(60);
+    }
+
+    @Test
+    void cvUploadedKey_isApplicationId() throws InterruptedException {
+        CvUploadedEvent event = CvUploadedEvent.of(42L, 1L, 1L, "/cv/42.pdf");
+        publisher.publishCvUploaded(event);
+
+        ConsumerRecord<String, Object> received = records.poll(5, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.key()).isEqualTo("42");
+    }
+
+    @Test
+    void examBatchKey_isBatchId() throws InterruptedException {
+        ExamBatchReadyEvent event = ExamBatchReadyEvent.of(
+                77L, 1L, List.of(10L), 90, Instant.now());
+        publisher.publishExamBatchReady(event);
+
+        ConsumerRecord<String, Object> received = records.poll(5, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.key()).isEqualTo("77");
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -24,7 +24,15 @@ spring:
   flyway:
     enabled: false
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: ${spring.embedded.kafka.brokers:localhost:9092}
+    producer:
+      acks: "1"
+      retries: 1
+      properties:
+        enable.idempotence: false
+    consumer:
+      group-id: recruit-backend-test
+      auto-offset-reset: earliest
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## Summary

- **`KafkaTopics`** — single source of truth for all topic name constants (`CV_UPLOADED`, `EXAM_BATCH_READY`, `EXAM_COMPLETED`, `EXAM_SUBMITTED`)
- **Event records** — `CvUploadedEvent` (applicationId, candidateId, jobId, cvStoragePath, occurredAt) and `ExamBatchReadyEvent` (batchId, jobId, candidateIds, durationMinutes, scheduledAt, occurredAt) with factory methods
- **`KafkaConfig`** — idempotent `ProducerFactory` with `acks=all`, retries, 500ms backoff; `KafkaTemplate<String, Object>`; `NewTopic` beans for all four system topics (3 partitions each)
- **`KafkaEventPublisher`** — `publishCvUploaded` / `publishExamBatchReady` with partition key strategy (applicationId / batchId for ordering); async `whenComplete` callback logs partition+offset on success or full exception on failure
- **`application.yml`** — producer acks/retries/idempotence externalized via `KAFKA_PRODUCER_ACKS` / `KAFKA_PRODUCER_RETRIES`; consumer `auto-offset-reset: earliest`

## Test plan

- [ ] `publishCvUploaded` → message arrives on `CV_UPLOADED`, key = applicationId, payload fields match
- [ ] `publishExamBatchReady` → message arrives on `EXAM_BATCH_READY`, key = batchId, candidateIds list preserved
- [ ] Key routing: applicationId → `"42"`, batchId → `"77"` (partition ordering guarantee)
- [ ] All four topics auto-created on embedded broker startup

