### PR TITLE
feat(backend): Redis Lettuce pool and OTP caching (FR-06)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.apache.commons:commons-pool2'
 
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
@@ -55,6 +56,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'com.h2database:h2'
+
+    // Embedded Redis for integration tests
+    testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/eaa/recruit/cache/OtpCacheService.java
+++ b/backend/src/main/java/com/eaa/recruit/cache/OtpCacheService.java
@@ -1,0 +1,125 @@
+package com.eaa.recruit.cache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Manages OTP lifecycle in Redis.
+ *
+ * Key schema : otp:<identifier>   (identifier = email or phone)
+ * TTL        : configurable via otp.ttl-seconds (default 5 min)
+ *
+ * Graceful degradation: Redis failures are caught, logged, and surfaced
+ * as empty Optional / false rather than propagating up to the caller.
+ * The registration flow can decide whether to retry or fail fast.
+ */
+@Service
+public class OtpCacheService {
+
+    private static final Logger log = LoggerFactory.getLogger(OtpCacheService.class);
+
+    private final StringRedisTemplate redis;
+    private final OtpProperties props;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public OtpCacheService(StringRedisTemplate redis, OtpProperties props) {
+        this.redis = redis;
+        this.props = props;
+    }
+
+    /**
+     * Generates a random OTP, stores it in Redis with TTL, and returns the value.
+     *
+     * @param identifier unique key (e.g. email address)
+     * @return the generated OTP, or empty if Redis is unavailable
+     */
+    public Optional<String> generateAndStore(String identifier) {
+        String otp = generateOtp();
+        String key = buildKey(identifier);
+        Duration ttl = Duration.ofSeconds(props.getTtlSeconds());
+
+        try {
+            redis.opsForValue().set(key, otp, ttl);
+            log.debug("OTP stored for identifier='{}' ttl={}s", identifier, props.getTtlSeconds());
+            return Optional.of(otp);
+        } catch (DataAccessException ex) {
+            log.error("Redis unavailable — could not store OTP for identifier='{}': {}",
+                    identifier, ex.getMessage(), ex);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Validates the supplied OTP against the stored value.
+     * Deletes the key on match (single-use enforcement).
+     *
+     * @return true if match, false if mismatch, expired, or Redis unavailable
+     */
+    public boolean validateAndConsume(String identifier, String candidateOtp) {
+        String key = buildKey(identifier);
+
+        try {
+            String stored = redis.opsForValue().get(key);
+            if (stored == null) {
+                log.debug("OTP not found or expired for identifier='{}'", identifier);
+                return false;
+            }
+            if (!stored.equals(candidateOtp)) {
+                log.debug("OTP mismatch for identifier='{}'", identifier);
+                return false;
+            }
+            redis.delete(key);
+            log.debug("OTP validated and consumed for identifier='{}'", identifier);
+            return true;
+        } catch (DataAccessException ex) {
+            log.error("Redis unavailable — could not validate OTP for identifier='{}': {}",
+                    identifier, ex.getMessage(), ex);
+            return false;
+        }
+    }
+
+    /**
+     * Explicitly invalidates an OTP (e.g. on max-attempts exceeded).
+     */
+    public void invalidate(String identifier) {
+        try {
+            redis.delete(buildKey(identifier));
+        } catch (DataAccessException ex) {
+            log.warn("Redis unavailable — could not invalidate OTP for identifier='{}': {}",
+                    identifier, ex.getMessage());
+        }
+    }
+
+    /**
+     * Returns the remaining TTL in seconds.
+     * -2 = key does not exist, -1 = no expiry set, empty = Redis unavailable.
+     */
+    public Optional<Long> getRemainingTtl(String identifier) {
+        try {
+            Long seconds = redis.getExpire(buildKey(identifier));
+            return Optional.ofNullable(seconds);
+        } catch (DataAccessException ex) {
+            log.warn("Redis unavailable — could not get TTL for identifier='{}'", identifier);
+            return Optional.empty();
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private String buildKey(String identifier) {
+        return props.getKeyPrefix() + identifier;
+    }
+
+    private String generateOtp() {
+        int max = (int) Math.pow(10, props.getLength());
+        int value = secureRandom.nextInt(max);
+        return String.format("%0" + props.getLength() + "d", value);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/cache/OtpProperties.java
+++ b/backend/src/main/java/com/eaa/recruit/cache/OtpProperties.java
@@ -1,0 +1,22 @@
+package com.eaa.recruit.cache;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "otp")
+public class OtpProperties {
+
+    private long ttlSeconds = 300;
+    private int length = 6;
+    private String keyPrefix = "otp:";
+
+    public long getTtlSeconds() { return ttlSeconds; }
+    public void setTtlSeconds(long ttlSeconds) { this.ttlSeconds = ttlSeconds; }
+
+    public int getLength() { return length; }
+    public void setLength(int length) { this.length = length; }
+
+    public String getKeyPrefix() { return keyPrefix; }
+    public void setKeyPrefix(String keyPrefix) { this.keyPrefix = keyPrefix; }
+}

--- a/backend/src/main/java/com/eaa/recruit/config/RedisConfig.java
+++ b/backend/src/main/java/com/eaa/recruit/config/RedisConfig.java
@@ -1,0 +1,78 @@
+package com.eaa.recruit.config;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host:localhost}")
+    private String host;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int port;
+
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
+    @Value("${spring.data.redis.connect-timeout:1000ms}")
+    private Duration connectTimeout;
+
+    @Value("${spring.data.redis.lettuce.pool.min-idle:2}")
+    private int minIdle;
+
+    @Value("${spring.data.redis.lettuce.pool.max-idle:8}")
+    private int maxIdle;
+
+    @Value("${spring.data.redis.lettuce.pool.max-active:16}")
+    private int maxActive;
+
+    @Value("${spring.data.redis.lettuce.pool.max-wait:500ms}")
+    private Duration maxWait;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration serverConfig = new RedisStandaloneConfiguration(host, port);
+        if (StringUtils.hasText(password)) {
+            serverConfig.setPassword(password);
+        }
+
+        GenericObjectPoolConfig<?> poolConfig = new GenericObjectPoolConfig<>();
+        poolConfig.setMinIdle(minIdle);
+        poolConfig.setMaxIdle(maxIdle);
+        poolConfig.setMaxTotal(maxActive);
+        poolConfig.setMaxWait(maxWait);
+        poolConfig.setTestOnBorrow(true);
+        poolConfig.setTestWhileIdle(true);
+
+        LettucePoolingClientConfiguration clientConfig = LettucePoolingClientConfiguration.builder()
+                .commandTimeout(connectTimeout)
+                .poolConfig(poolConfig)
+                .build();
+
+        return new LettuceConnectionFactory(serverConfig, clientConfig);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory factory) {
+        StringRedisTemplate template = new StringRedisTemplate();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,6 +41,17 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      timeout: ${REDIS_COMMAND_TIMEOUT:2000ms}
+      connect-timeout: ${REDIS_CONNECT_TIMEOUT:1000ms}
+      lettuce:
+        pool:
+          enabled: true
+          min-idle: ${REDIS_POOL_MIN_IDLE:2}
+          max-idle: ${REDIS_POOL_MAX_IDLE:8}
+          max-active: ${REDIS_POOL_MAX_ACTIVE:16}
+          max-wait: ${REDIS_POOL_MAX_WAIT:500ms}
+        shutdown-timeout: 200ms
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
@@ -73,3 +84,8 @@ management:
 jwt:
   secret: ${JWT_SECRET:change-me-in-production-min-256-bits-long-secret-key}
   expiration-ms: ${JWT_EXPIRATION_MS:86400000}
+
+otp:
+  ttl-seconds: ${OTP_TTL_SECONDS:300}
+  length: ${OTP_LENGTH:6}
+  key-prefix: "otp:"

--- a/backend/src/test/java/com/eaa/recruit/cache/OtpCacheIntegrationTest.java
+++ b/backend/src/test/java/com/eaa/recruit/cache/OtpCacheIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.eaa.recruit.cache;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import redis.embedded.RedisServer;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test against a real embedded Redis.
+ * Verifies OTP store/validate round-trip and TTL enforcement.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class OtpCacheIntegrationTest {
+
+    private static RedisServer redisServer;
+    private static int redisPort;
+
+    @BeforeAll
+    static void startRedis() throws Exception {
+        redisPort = findFreePort();
+        redisServer = new RedisServer(redisPort);
+        redisServer.start();
+    }
+
+    @AfterAll
+    static void stopRedis() throws Exception {
+        if (redisServer != null && redisServer.isActive()) {
+            redisServer.stop();
+        }
+    }
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", () -> "127.0.0.1");
+        registry.add("spring.data.redis.port", () -> redisPort);
+        registry.add("otp.ttl-seconds", () -> "2"); // short TTL for expiry test
+    }
+
+    @Autowired OtpCacheService otpCacheService;
+
+    @Test
+    void storeAndValidateOtp_roundTrip() {
+        Optional<String> otp = otpCacheService.generateAndStore("test@example.com");
+
+        assertThat(otp).isPresent();
+        assertThat(otpCacheService.validateAndConsume("test@example.com", otp.get())).isTrue();
+        // key deleted after consume — second attempt fails
+        assertThat(otpCacheService.validateAndConsume("test@example.com", otp.get())).isFalse();
+    }
+
+    @Test
+    void expiredOtp_isRejected() throws InterruptedException {
+        Optional<String> otp = otpCacheService.generateAndStore("expire@example.com");
+        assertThat(otp).isPresent();
+
+        // Wait for TTL=2s to expire
+        Thread.sleep(3_000);
+
+        assertThat(otpCacheService.validateAndConsume("expire@example.com", otp.get())).isFalse();
+    }
+
+    @Test
+    void remainingTtl_isPositiveRightAfterStore() {
+        otpCacheService.generateAndStore("ttl@example.com");
+        Optional<Long> ttl = otpCacheService.getRemainingTtl("ttl@example.com");
+
+        assertThat(ttl).isPresent();
+        assertThat(ttl.get()).isGreaterThan(0L);
+    }
+
+    @Test
+    void invalidate_removesKey() {
+        otpCacheService.generateAndStore("invalidate@example.com");
+        otpCacheService.invalidate("invalidate@example.com");
+
+        assertThat(otpCacheService.validateAndConsume("invalidate@example.com", "000000")).isFalse();
+    }
+
+    // ── utility ──────────────────────────────────────────────────────────────
+
+    private static int findFreePort() throws Exception {
+        try (java.net.ServerSocket socket = new java.net.ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/cache/OtpCacheServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/cache/OtpCacheServiceTest.java
@@ -1,0 +1,146 @@
+package com.eaa.recruit.cache;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OtpCacheServiceTest {
+
+    @Mock StringRedisTemplate redis;
+    @Mock ValueOperations<String, String> valueOps;
+
+    OtpCacheService service;
+
+    @BeforeEach
+    void setUp() {
+        OtpProperties props = new OtpProperties();
+        props.setTtlSeconds(300);
+        props.setLength(6);
+        props.setKeyPrefix("otp:");
+        when(redis.opsForValue()).thenReturn(valueOps);
+        service = new OtpCacheService(redis, props);
+    }
+
+    // ── generateAndStore ─────────────────────────────────────────────────────
+
+    @Test
+    void generateAndStore_returnsOtp_andStoresWithTtl() {
+        Optional<String> result = service.generateAndStore("alice@example.com");
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).matches("\\d{6}");
+        verify(valueOps).set(eq("otp:alice@example.com"), eq(result.get()),
+                eq(Duration.ofSeconds(300)));
+    }
+
+    @Test
+    void generateAndStore_returnsEmpty_whenRedisDown() {
+        doThrow(new DataAccessResourceFailureException("Redis down"))
+                .when(valueOps).set(anyString(), anyString(), any(Duration.class));
+
+        Optional<String> result = service.generateAndStore("alice@example.com");
+
+        assertThat(result).isEmpty();
+    }
+
+    // ── validateAndConsume ───────────────────────────────────────────────────
+
+    @Test
+    void validateAndConsume_returnsTrue_andDeletesKey_onMatch() {
+        when(valueOps.get("otp:bob@example.com")).thenReturn("123456");
+
+        boolean valid = service.validateAndConsume("bob@example.com", "123456");
+
+        assertThat(valid).isTrue();
+        verify(redis).delete("otp:bob@example.com");
+    }
+
+    @Test
+    void validateAndConsume_returnsFalse_onMismatch() {
+        when(valueOps.get("otp:bob@example.com")).thenReturn("999999");
+
+        boolean valid = service.validateAndConsume("bob@example.com", "123456");
+
+        assertThat(valid).isFalse();
+        verify(redis, never()).delete(anyString());
+    }
+
+    @Test
+    void validateAndConsume_returnsFalse_whenKeyExpiredOrMissing() {
+        when(valueOps.get("otp:bob@example.com")).thenReturn(null);
+
+        boolean valid = service.validateAndConsume("bob@example.com", "123456");
+
+        assertThat(valid).isFalse();
+    }
+
+    @Test
+    void validateAndConsume_returnsFalse_whenRedisDown() {
+        when(valueOps.get(anyString()))
+                .thenThrow(new DataAccessResourceFailureException("Redis down"));
+
+        boolean valid = service.validateAndConsume("bob@example.com", "123456");
+
+        assertThat(valid).isFalse();
+    }
+
+    // ── invalidate ───────────────────────────────────────────────────────────
+
+    @Test
+    void invalidate_deletesKey() {
+        service.invalidate("carol@example.com");
+        verify(redis).delete("otp:carol@example.com");
+    }
+
+    @Test
+    void invalidate_doesNotThrow_whenRedisDown() {
+        doThrow(new DataAccessResourceFailureException("Redis down"))
+                .when(redis).delete(anyString());
+
+        // must not propagate
+        service.invalidate("carol@example.com");
+    }
+
+    // ── OTP format ───────────────────────────────────────────────────────────
+
+    @Test
+    void generatedOtp_isAlwaysSixDigits() {
+        for (int i = 0; i < 20; i++) {
+            Optional<String> otp = service.generateAndStore("x@x.com");
+            assertThat(otp).isPresent();
+            assertThat(otp.get()).hasSize(6).matches("\\d{6}");
+        }
+    }
+
+    // ── getRemainingTtl ──────────────────────────────────────────────────────
+
+    @Test
+    void getRemainingTtl_returnsSeconds_whenKeyExists() {
+        when(redis.getExpire("otp:x@x.com")).thenReturn(180L);
+
+        Optional<Long> ttl = service.getRemainingTtl("x@x.com");
+
+        assertThat(ttl).hasValue(180L);
+    }
+
+    @Test
+    void getRemainingTtl_returnsEmpty_whenRedisDown() {
+        when(redis.getExpire(anyString()))
+                .thenThrow(new DataAccessResourceFailureException("Redis down"));
+
+        assertThat(service.getRemainingTtl("x@x.com")).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- **`RedisConfig`** — `LettucePoolingClientConfiguration` with min/max idle, max-active, max-wait, and connect-timeout all externalized via `spring.data.redis.*` env vars; optional password support; `StringRedisTemplate` with string serializers throughout
- **`OtpProperties`** — `@ConfigurationProperties(prefix="otp")` binding `ttl-seconds` (default 300), `length` (default 6), `key-prefix` (default `otp:`)
- **`OtpCacheService`** — full OTP lifecycle:
  - `generateAndStore(identifier)` — `SecureRandom` 6-digit code, stored with TTL via `SETEX`; returns `Optional.empty()` on Redis failure
  - `validateAndConsume(identifier, otp)` — match + atomic `DEL` for single-use; returns `false` on mismatch/expiry/Redis failure
  - `invalidate(identifier)` — explicit delete (max-attempts exceeded)
  - `getRemainingTtl(identifier)` — seconds remaining, `-2` = missing, empty = Redis unavailable
- **Graceful degradation** — every Redis call wrapped in `DataAccessException` catch; logs error, returns safe fallback, never propagates

## Test plan

- [ ] `OtpCacheServiceTest` (unit, Mockito) — store/validate round-trip, mismatch, expired key, Redis-down on store, Redis-down on validate, invalidate Redis-down, OTP always 6 digits, TTL get
- [ ] `OtpCacheIntegrationTest` (embedded Redis, `@DynamicPropertySource`) — real store/validate, single-use enforcement, TTL=2s expiry (sleeps 3s), invalidate removes key, positive TTL right after store

## Dependencies added
- `org.apache.commons:commons-pool2` — required for Lettuce pooling
- `com.github.codemonstur:embedded-redis:1.4.3` — test-scoped

