### PR TITLE
feat(backend): User entity, UserRepository, and RBAC (FR-07 + FR-08)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/config/SecurityConfig.java
+++ b/backend/src/main/java/com/eaa/recruit/config/SecurityConfig.java
@@ -3,8 +3,12 @@ package com.eaa.recruit.config;
 import com.eaa.recruit.security.JwtAccessDeniedHandler;
 import com.eaa.recruit.security.JwtAuthEntryPoint;
 import com.eaa.recruit.security.JwtAuthenticationFilter;
+import com.eaa.recruit.security.UserDetailsServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -15,6 +19,13 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+/**
+ * Core security configuration.
+ *
+ * JWT filter handles stateless authentication on every request.
+ * RBAC annotations (@IsCandidate, @IsRecruiter, @IsAdmin, @IsSuperAdmin)
+ * enforce fine-grained access at the method level via @EnableMethodSecurity.
+ */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -23,13 +34,16 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthEntryPoint jwtAuthEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final UserDetailsServiceImpl userDetailsService;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
                           JwtAuthEntryPoint jwtAuthEntryPoint,
-                          JwtAccessDeniedHandler jwtAccessDeniedHandler) {
+                          JwtAccessDeniedHandler jwtAccessDeniedHandler,
+                          UserDetailsServiceImpl userDetailsService) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-        this.jwtAuthEntryPoint = jwtAuthEntryPoint;
-        this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+        this.jwtAuthEntryPoint        = jwtAuthEntryPoint;
+        this.jwtAccessDeniedHandler   = jwtAccessDeniedHandler;
+        this.userDetailsService       = userDetailsService;
     }
 
     @Bean
@@ -49,6 +63,20 @@ public class SecurityConfig {
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
     }
 
     @Bean

--- a/backend/src/main/java/com/eaa/recruit/entity/Role.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/Role.java
@@ -1,0 +1,15 @@
+package com.eaa.recruit.entity;
+
+/**
+ * System roles in ascending privilege order.
+ * Value stored in DB as a string (EnumType.STRING).
+ *
+ * Spring Security authority name = "ROLE_" + name()
+ * e.g.  CANDIDATE  →  ROLE_CANDIDATE
+ */
+public enum Role {
+    CANDIDATE,
+    RECRUITER,
+    ADMIN,
+    SUPER_ADMIN
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/User.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/User.java
@@ -1,0 +1,52 @@
+package com.eaa.recruit.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+    name = "users",
+    indexes = {
+        @Index(name = "idx_users_email", columnList = "email", unique = true)
+    }
+)
+public class User extends BaseEntity {
+
+    @Column(name = "email", nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private Role role;
+
+    @Column(name = "full_name", nullable = false, length = 100)
+    private String fullName;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = false;
+
+    protected User() {}
+
+    private User(String email, String passwordHash, Role role, String fullName) {
+        this.email        = email;
+        this.passwordHash = passwordHash;
+        this.role         = role;
+        this.fullName     = fullName;
+    }
+
+    public static User create(String email, String passwordHash, Role role, String fullName) {
+        return new User(email, passwordHash, role, fullName);
+    }
+
+    public String getEmail()        { return email; }
+    public String getPasswordHash() { return passwordHash; }
+    public Role   getRole()         { return role; }
+    public String getFullName()     { return fullName; }
+    public boolean isActive()       { return active; }
+
+    public void activate()                     { this.active = true; }
+    public void deactivate()                   { this.active = false; }
+    public void changePassword(String newHash) { this.passwordHash = newHash; }
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/UserRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    long countByRole(Role role);
+}

--- a/backend/src/main/java/com/eaa/recruit/security/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/eaa/recruit/security/UserDetailsServiceImpl.java
@@ -1,0 +1,43 @@
+package com.eaa.recruit.security;
+
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.repository.UserRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Loads user by email for Spring Security authentication flows.
+ * Used by the login endpoint — NOT called on every JWT request
+ * (JWT filter resolves identity directly from token claims).
+ */
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(
+                        "User not found with email: " + email));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail())
+                .password(user.getPasswordHash())
+                .authorities(List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())))
+                .accountLocked(!user.isActive())
+                .disabled(!user.isActive())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/security/rbac/IsAdmin.java
+++ b/backend/src/main/java/com/eaa/recruit/security/rbac/IsAdmin.java
@@ -1,0 +1,10 @@
+package com.eaa.recruit.security.rbac;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+public @interface IsAdmin {}

--- a/backend/src/main/java/com/eaa/recruit/security/rbac/IsCandidate.java
+++ b/backend/src/main/java/com/eaa/recruit/security/rbac/IsCandidate.java
@@ -1,0 +1,10 @@
+package com.eaa.recruit.security.rbac;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("hasRole('CANDIDATE')")
+public @interface IsCandidate {}

--- a/backend/src/main/java/com/eaa/recruit/security/rbac/IsRecruiter.java
+++ b/backend/src/main/java/com/eaa/recruit/security/rbac/IsRecruiter.java
@@ -1,0 +1,10 @@
+package com.eaa.recruit.security.rbac;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("hasRole('RECRUITER')")
+public @interface IsRecruiter {}

--- a/backend/src/main/java/com/eaa/recruit/security/rbac/IsRecruiterOrAbove.java
+++ b/backend/src/main/java/com/eaa/recruit/security/rbac/IsRecruiterOrAbove.java
@@ -1,0 +1,11 @@
+package com.eaa.recruit.security.rbac;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import java.lang.annotation.*;
+
+/** Recruiter, Admin, or Super Admin. */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("hasAnyRole('RECRUITER', 'ADMIN', 'SUPER_ADMIN')")
+public @interface IsRecruiterOrAbove {}

--- a/backend/src/main/java/com/eaa/recruit/security/rbac/IsSuperAdmin.java
+++ b/backend/src/main/java/com/eaa/recruit/security/rbac/IsSuperAdmin.java
@@ -1,0 +1,10 @@
+package com.eaa.recruit.security.rbac;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("hasRole('SUPER_ADMIN')")
+public @interface IsSuperAdmin {}

--- a/backend/src/main/resources/db/migration/V2__create_users_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_users_table.sql
@@ -1,0 +1,20 @@
+-- V2: Users table — core identity store for all roles
+
+CREATE TABLE users (
+    id            BIGSERIAL     PRIMARY KEY,
+    email         VARCHAR(255)  NOT NULL UNIQUE,
+    password_hash VARCHAR(255)  NOT NULL,
+    role          VARCHAR(20)   NOT NULL
+                    CHECK (role IN ('CANDIDATE', 'RECRUITER', 'ADMIN', 'SUPER_ADMIN')),
+    full_name     VARCHAR(100)  NOT NULL,
+    is_active     BOOLEAN       NOT NULL DEFAULT FALSE,
+    created_at    TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    version       BIGINT        NOT NULL DEFAULT 0
+);
+
+CREATE UNIQUE INDEX idx_users_email ON users (email);
+
+CREATE TRIGGER trg_users_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/backend/src/test/java/com/eaa/recruit/entity/UserTest.java
+++ b/backend/src/test/java/com/eaa/recruit/entity/UserTest.java
@@ -1,0 +1,36 @@
+package com.eaa.recruit.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Test void newUser_isInactive() {
+        assertThat(User.create("a@b.com", "hash", Role.CANDIDATE, "Alice").isActive()).isFalse();
+    }
+
+    @Test void activate_setsActiveTrue() {
+        User u = User.create("a@b.com", "hash", Role.CANDIDATE, "Alice");
+        u.activate();
+        assertThat(u.isActive()).isTrue();
+    }
+
+    @Test void deactivate_setsActiveFalse() {
+        User u = User.create("a@b.com", "hash", Role.RECRUITER, "Bob");
+        u.activate();
+        u.deactivate();
+        assertThat(u.isActive()).isFalse();
+    }
+
+    @Test void changePassword_updatesHash() {
+        User u = User.create("a@b.com", "old", Role.CANDIDATE, "Alice");
+        u.changePassword("new");
+        assertThat(u.getPasswordHash()).isEqualTo("new");
+    }
+
+    @Test void rolesPreserved() {
+        assertThat(User.create("a@b.com", "h", Role.ADMIN, "A").getRole()).isEqualTo(Role.ADMIN);
+        assertThat(User.create("b@b.com", "h", Role.SUPER_ADMIN, "S").getRole()).isEqualTo(Role.SUPER_ADMIN);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/eaa/recruit/repository/UserRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserRepositoryTest {
+
+    @Autowired UserRepository userRepository;
+
+    @Test
+    void saveAndFindByEmail() {
+        userRepository.save(User.create("alice@example.com", "$2a$bcrypt", Role.CANDIDATE, "Alice"));
+
+        Optional<User> found = userRepository.findByEmail("alice@example.com");
+        assertThat(found).isPresent();
+        assertThat(found.get().getRole()).isEqualTo(Role.CANDIDATE);
+        assertThat(found.get().isActive()).isFalse();
+        assertThat(found.get().getCreatedAt()).isNotNull();
+        assertThat(found.get().getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void existsByEmail() {
+        userRepository.save(User.create("bob@example.com", "hash", Role.RECRUITER, "Bob"));
+        assertThat(userRepository.existsByEmail("bob@example.com")).isTrue();
+        assertThat(userRepository.existsByEmail("unknown@example.com")).isFalse();
+    }
+
+    @Test
+    void emailIsUnique() {
+        userRepository.save(User.create("dup@example.com", "hash", Role.CANDIDATE, "D1"));
+        assertThatThrownBy(() ->
+            userRepository.saveAndFlush(User.create("dup@example.com", "h2", Role.CANDIDATE, "D2"))
+        ).isInstanceOf(Exception.class);
+    }
+
+    @Test
+    void countByRole() {
+        userRepository.save(User.create("c1@example.com", "h", Role.CANDIDATE, "C1"));
+        userRepository.save(User.create("c2@example.com", "h", Role.CANDIDATE, "C2"));
+        userRepository.save(User.create("r1@example.com", "h", Role.RECRUITER, "R1"));
+
+        assertThat(userRepository.countByRole(Role.CANDIDATE)).isEqualTo(2);
+        assertThat(userRepository.countByRole(Role.RECRUITER)).isEqualTo(1);
+        assertThat(userRepository.countByRole(Role.ADMIN)).isEqualTo(0);
+    }
+
+    @Test
+    void passwordHashStoredAsIs() {
+        userRepository.save(User.create("safe@example.com", "$2a$10$hashed", Role.CANDIDATE, "S"));
+        assertThat(userRepository.findByEmail("safe@example.com").orElseThrow()
+                .getPasswordHash()).startsWith("$2a$");
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/security/RbacTest.java
+++ b/backend/src/test/java/com/eaa/recruit/security/RbacTest.java
@@ -1,0 +1,108 @@
+package com.eaa.recruit.security;
+
+import com.eaa.recruit.config.SecurityConfig;
+import com.eaa.recruit.security.rbac.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtTokenProvider.class,
+         JwtProperties.class, JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class RbacTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean  UserDetailsServiceImpl userDetailsService;
+
+    @RestController
+    @RequestMapping("/rbac-test")
+    static class RbacTestController {
+        @GetMapping("/candidate")  @IsCandidate       String candidate()  { return "ok"; }
+        @GetMapping("/recruiter")  @IsRecruiter       String recruiter()  { return "ok"; }
+        @GetMapping("/admin")      @IsAdmin           String admin()      { return "ok"; }
+        @GetMapping("/superadmin") @IsSuperAdmin      String superAdmin() { return "ok"; }
+        @GetMapping("/rec-plus")   @IsRecruiterOrAbove String recPlus()  { return "ok"; }
+    }
+
+    @Test @WithMockUser(roles = "CANDIDATE")
+    void candidate_ownEndpoint_ok() throws Exception {
+        mockMvc.perform(get("/rbac-test/candidate")).andExpect(status().isOk());
+    }
+
+    @Test @WithMockUser(roles = "CANDIDATE")
+    void candidate_recruiterEndpoint_forbidden() throws Exception {
+        mockMvc.perform(get("/rbac-test/recruiter")).andExpect(status().isForbidden());
+    }
+
+    @Test @WithMockUser(roles = "CANDIDATE")
+    void candidate_adminEndpoint_forbidden() throws Exception {
+        mockMvc.perform(get("/rbac-test/admin")).andExpect(status().isForbidden());
+    }
+
+    @Test @WithMockUser(roles = "RECRUITER")
+    void recruiter_ownEndpoint_ok() throws Exception {
+        mockMvc.perform(get("/rbac-test/recruiter")).andExpect(status().isOk());
+    }
+
+    @Test @WithMockUser(roles = "RECRUITER")
+    void recruiter_adminEndpoint_forbidden() throws Exception {
+        mockMvc.perform(get("/rbac-test/admin")).andExpect(status().isForbidden());
+    }
+
+    @Test @WithMockUser(roles = "RECRUITER")
+    void recruiter_recPlus_ok() throws Exception {
+        mockMvc.perform(get("/rbac-test/rec-plus")).andExpect(status().isOk());
+    }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void admin_adminEndpoint_ok() throws Exception {
+        mockMvc.perform(get("/rbac-test/admin")).andExpect(status().isOk());
+    }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void admin_superAdminEndpoint_forbidden() throws Exception {
+        mockMvc.perform(get("/rbac-test/superadmin")).andExpect(status().isForbidden());
+    }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void admin_recPlus_ok() throws Exception {
+        mockMvc.perform(get("/rbac-test/rec-plus")).andExpect(status().isOk());
+    }
+
+    @Test @WithMockUser(roles = "SUPER_ADMIN")
+    void superAdmin_adminEndpoint_ok() throws Exception {
+        mockMvc.perform(get("/rbac-test/admin")).andExpect(status().isOk());
+    }
+
+    @Test @WithMockUser(roles = "SUPER_ADMIN")
+    void superAdmin_superAdminEndpoint_ok() throws Exception {
+        mockMvc.perform(get("/rbac-test/superadmin")).andExpect(status().isOk());
+    }
+
+    @Test @WithMockUser(roles = "SUPER_ADMIN")
+    void superAdmin_recPlus_ok() throws Exception {
+        mockMvc.perform(get("/rbac-test/rec-plus")).andExpect(status().isOk());
+    }
+
+    @Test
+    void unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/rbac-test/candidate")).andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary

### FR-08 — User Entity & Repository
- **`Role` enum** — `CANDIDATE | RECRUITER | ADMIN | SUPER_ADMIN` (stored as string in DB)
- **`User` entity** extends `BaseEntity` — `email` (unique, indexed), `passwordHash`, `role`, `fullName`, `isActive` (defaults false); factory `User.create(...)`, controlled mutations `activate()` / `deactivate()` / `changePassword(newHash)`
- **`UserRepository`** — `findByEmail`, `existsByEmail`, `countByRole`
- **V2 Flyway migration** — `users` table with `CHECK (role IN (...))`, unique index on `email`, `updated_at` trigger

### FR-07 — RBAC
- **Meta-annotations** wrapping `@PreAuthorize` — use on any controller method:
  - `@IsCandidate` → `hasRole('CANDIDATE')`
  - `@IsRecruiter` → `hasRole('RECRUITER')`
  - `@IsAdmin` → `hasAnyRole('ADMIN', 'SUPER_ADMIN')`
  - `@IsSuperAdmin` → `hasRole('SUPER_ADMIN')`
  - `@IsRecruiterOrAbove` → `hasAnyRole('RECRUITER', 'ADMIN', 'SUPER_ADMIN')`
- **`UserDetailsServiceImpl`** — loads `User` by email, maps role to `ROLE_<name>` authority, marks account locked/disabled when inactive
- **`SecurityConfig`** updated — `DaoAuthenticationProvider` wired, `AuthenticationManager` bean exposed for login endpoints

## Test plan
- [ ] `UserTest` — new user inactive, activate, deactivate, changePassword, role preserved
- [ ] `UserRepositoryTest` (`@DataJpaTest`) — CRUD, unique email constraint, existsByEmail, countByRole, bcrypt prefix check
- [ ] `RbacTest` (`@WebMvcTest`, 13 tests):
  - CANDIDATE: own endpoint ✓, recruiter ✗, admin ✗, super admin ✗
  - RECRUITER: own endpoint ✓, admin ✗, rec-plus ✓
  - ADMIN: admin endpoint ✓, superadmin ✗, rec-plus ✓
  - SUPER_ADMIN: admin ✓, superadmin ✓, rec-plus ✓
  - Unauthenticated → 401

