### PR TITLE
feat(backend): OTP service with notification and verification (FR-09)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/otp/MockOtpNotificationAdapter.java
+++ b/backend/src/main/java/com/eaa/recruit/otp/MockOtpNotificationAdapter.java
@@ -1,0 +1,28 @@
+package com.eaa.recruit.otp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mock OTP notification adapter for development and test environments.
+ *
+ * Logs the OTP to the console instead of sending a real email or SMS.
+ * Active on all profiles except "prod". In production, replace with a
+ * real SMTP / Twilio adapter and annotate with @Profile("prod").
+ */
+@Component
+@Profile("!prod")
+public class MockOtpNotificationAdapter implements OtpNotificationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockOtpNotificationAdapter.class);
+
+    @Override
+    public void send(String recipient, String otp) {
+        log.info("╔══════════════════════════════════════╗");
+        log.info("║  [MOCK OTP]  Recipient : {}",  recipient);
+        log.info("║  [MOCK OTP]  Code      : {}",  otp);
+        log.info("╚══════════════════════════════════════╝");
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/otp/OtpNotificationPort.java
+++ b/backend/src/main/java/com/eaa/recruit/otp/OtpNotificationPort.java
@@ -1,0 +1,14 @@
+package com.eaa.recruit.otp;
+
+/**
+ * Port for dispatching OTP codes to users.
+ * Swap implementations per environment (mock in dev, real email/SMS in prod).
+ */
+public interface OtpNotificationPort {
+
+    /**
+     * @param recipient email address or phone number
+     * @param otp       the 6-digit code to deliver
+     */
+    void send(String recipient, String otp);
+}

--- a/backend/src/main/java/com/eaa/recruit/otp/OtpService.java
+++ b/backend/src/main/java/com/eaa/recruit/otp/OtpService.java
@@ -1,0 +1,106 @@
+package com.eaa.recruit.otp;
+
+import com.eaa.recruit.cache.OtpCacheService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Orchestrates the full OTP lifecycle:
+ *   1. generate + store in Redis (via OtpCacheService)
+ *   2. dispatch to user (via OtpNotificationPort)
+ *   3. verify submission and return a typed result
+ *
+ * Uses OtpCacheService's getRemainingTtl to distinguish "expired"
+ * from "never existed / already consumed" for a clearer UX message.
+ */
+@Service
+public class OtpService {
+
+    private static final Logger log = LoggerFactory.getLogger(OtpService.class);
+
+    private final OtpCacheService otpCacheService;
+    private final OtpNotificationPort notificationPort;
+    private final StringRedisTemplate redis;
+    private final com.eaa.recruit.cache.OtpProperties props;
+
+    public OtpService(OtpCacheService otpCacheService,
+                      OtpNotificationPort notificationPort,
+                      StringRedisTemplate redis,
+                      com.eaa.recruit.cache.OtpProperties props) {
+        this.otpCacheService  = otpCacheService;
+        this.notificationPort = notificationPort;
+        this.redis            = redis;
+        this.props            = props;
+    }
+
+    /**
+     * Generates, stores, and dispatches a new OTP to the given recipient.
+     *
+     * @param recipient email or phone — used as the Redis key and delivery address
+     * @return true if the OTP was stored and dispatched successfully
+     */
+    public boolean sendOtp(String recipient) {
+        Optional<String> otp = otpCacheService.generateAndStore(recipient);
+
+        if (otp.isEmpty()) {
+            log.error("OTP generation failed for recipient='{}' — Redis may be unavailable", recipient);
+            return false;
+        }
+
+        try {
+            notificationPort.send(recipient, otp.get());
+        } catch (Exception ex) {
+            // Notification failure should not block the flow — OTP is stored,
+            // user can request resend. Log and continue.
+            log.error("OTP notification failed for recipient='{}': {}", recipient, ex.getMessage(), ex);
+        }
+
+        return true;
+    }
+
+    /**
+     * Verifies a submitted OTP against the stored value.
+     *
+     * Returns a typed {@link OtpVerificationResult} distinguishing:
+     * - Success        — code matched and was consumed
+     * - Expired        — key existed before TTL but is now gone (inferred via TTL check)
+     * - Invalid        — key present but code wrong
+     * - ServiceUnavailable — Redis unavailable
+     */
+    public OtpVerificationResult verify(String recipient, String submittedOtp) {
+        // Peek at TTL to differentiate expired vs never-sent / already-consumed
+        Optional<Long> ttl = otpCacheService.getRemainingTtl(recipient);
+
+        if (ttl.isEmpty()) {
+            return new OtpVerificationResult.ServiceUnavailable();
+        }
+
+        // -2 means the key doesn't exist (expired or never set)
+        if (ttl.get() == -2L) {
+            log.debug("OTP key missing for recipient='{}' — likely expired or already used", recipient);
+            return new OtpVerificationResult.Expired();
+        }
+
+        boolean matched = otpCacheService.validateAndConsume(recipient, submittedOtp);
+
+        if (matched) {
+            log.info("OTP verified successfully for recipient='{}'", recipient);
+            return new OtpVerificationResult.Success();
+        } else {
+            log.debug("OTP mismatch for recipient='{}'", recipient);
+            return new OtpVerificationResult.Invalid();
+        }
+    }
+
+    /**
+     * Resends OTP — invalidates any existing code and issues a fresh one.
+     */
+    public boolean resendOtp(String recipient) {
+        otpCacheService.invalidate(recipient);
+        return sendOtp(recipient);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/otp/OtpVerificationResult.java
+++ b/backend/src/main/java/com/eaa/recruit/otp/OtpVerificationResult.java
@@ -1,0 +1,28 @@
+package com.eaa.recruit.otp;
+
+/**
+ * Result of an OTP verification attempt.
+ * Sealed to force exhaustive handling at call sites.
+ */
+public sealed interface OtpVerificationResult
+        permits OtpVerificationResult.Success,
+                OtpVerificationResult.Expired,
+                OtpVerificationResult.Invalid,
+                OtpVerificationResult.ServiceUnavailable {
+
+    record Success()            implements OtpVerificationResult {}
+    record Expired()            implements OtpVerificationResult {}
+    record Invalid()            implements OtpVerificationResult {}
+    record ServiceUnavailable() implements OtpVerificationResult {}
+
+    default boolean isSuccess() { return this instanceof Success; }
+
+    default String message() {
+        return switch (this) {
+            case Success ignored            -> "OTP verified successfully";
+            case Expired ignored            -> "OTP has expired. Please request a new one";
+            case Invalid ignored            -> "OTP is incorrect";
+            case ServiceUnavailable ignored -> "Verification service temporarily unavailable";
+        };
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/otp/MockOtpNotificationAdapterTest.java
+++ b/backend/src/test/java/com/eaa/recruit/otp/MockOtpNotificationAdapterTest.java
@@ -1,0 +1,15 @@
+package com.eaa.recruit.otp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class MockOtpNotificationAdapterTest {
+
+    @Test
+    void send_doesNotThrow() {
+        MockOtpNotificationAdapter adapter = new MockOtpNotificationAdapter();
+        assertThatCode(() -> adapter.send("test@example.com", "123456"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/otp/OtpServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/otp/OtpServiceTest.java
@@ -1,0 +1,140 @@
+package com.eaa.recruit.otp;
+
+import com.eaa.recruit.cache.OtpCacheService;
+import com.eaa.recruit.cache.OtpProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OtpServiceTest {
+
+    @Mock OtpCacheService otpCacheService;
+    @Mock OtpNotificationPort notificationPort;
+    @Mock StringRedisTemplate redis;
+
+    OtpService otpService;
+
+    @BeforeEach
+    void setUp() {
+        OtpProperties props = new OtpProperties();
+        props.setTtlSeconds(300);
+        props.setLength(6);
+        props.setKeyPrefix("otp:");
+        otpService = new OtpService(otpCacheService, notificationPort, redis, props);
+    }
+
+    // ── sendOtp ──────────────────────────────────────────────────────────────
+
+    @Test
+    void sendOtp_storesAndNotifies_returnsTrue() {
+        when(otpCacheService.generateAndStore("alice@example.com"))
+                .thenReturn(Optional.of("123456"));
+
+        boolean result = otpService.sendOtp("alice@example.com");
+
+        assertThat(result).isTrue();
+        verify(notificationPort).send("alice@example.com", "123456");
+    }
+
+    @Test
+    void sendOtp_returnsFalse_whenRedisUnavailable() {
+        when(otpCacheService.generateAndStore(anyString())).thenReturn(Optional.empty());
+
+        assertThat(otpService.sendOtp("alice@example.com")).isFalse();
+        verifyNoInteractions(notificationPort);
+    }
+
+    @Test
+    void sendOtp_returnsTrue_evenIfNotificationFails() {
+        when(otpCacheService.generateAndStore(anyString())).thenReturn(Optional.of("654321"));
+        doThrow(new RuntimeException("SMTP down")).when(notificationPort).send(anyString(), anyString());
+
+        // OTP is stored — sendOtp should still return true
+        assertThat(otpService.sendOtp("alice@example.com")).isTrue();
+    }
+
+    // ── verify ───────────────────────────────────────────────────────────────
+
+    @Test
+    void verify_returnsSuccess_whenOtpMatches() {
+        when(otpCacheService.getRemainingTtl("alice@example.com")).thenReturn(Optional.of(180L));
+        when(otpCacheService.validateAndConsume("alice@example.com", "123456")).thenReturn(true);
+
+        OtpVerificationResult result = otpService.verify("alice@example.com", "123456");
+
+        assertThat(result).isInstanceOf(OtpVerificationResult.Success.class);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.message()).isEqualTo("OTP verified successfully");
+    }
+
+    @Test
+    void verify_returnsInvalid_whenOtpMismatches() {
+        when(otpCacheService.getRemainingTtl("alice@example.com")).thenReturn(Optional.of(120L));
+        when(otpCacheService.validateAndConsume("alice@example.com", "000000")).thenReturn(false);
+
+        OtpVerificationResult result = otpService.verify("alice@example.com", "000000");
+
+        assertThat(result).isInstanceOf(OtpVerificationResult.Invalid.class);
+        assertThat(result.message()).isEqualTo("OTP is incorrect");
+    }
+
+    @Test
+    void verify_returnsExpired_whenKeyMissing() {
+        when(otpCacheService.getRemainingTtl("alice@example.com")).thenReturn(Optional.of(-2L));
+
+        OtpVerificationResult result = otpService.verify("alice@example.com", "123456");
+
+        assertThat(result).isInstanceOf(OtpVerificationResult.Expired.class);
+        assertThat(result.message()).contains("expired");
+        verifyNoMoreInteractions(otpCacheService);
+    }
+
+    @Test
+    void verify_returnsServiceUnavailable_whenRedisDown() {
+        when(otpCacheService.getRemainingTtl(anyString())).thenReturn(Optional.empty());
+
+        OtpVerificationResult result = otpService.verify("alice@example.com", "123456");
+
+        assertThat(result).isInstanceOf(OtpVerificationResult.ServiceUnavailable.class);
+        assertThat(result.isSuccess()).isFalse();
+    }
+
+    // ── resendOtp ─────────────────────────────────────────────────────────────
+
+    @Test
+    void resendOtp_invalidatesOldAndSendsNew() {
+        when(otpCacheService.generateAndStore("alice@example.com"))
+                .thenReturn(Optional.of("999999"));
+
+        boolean result = otpService.resendOtp("alice@example.com");
+
+        assertThat(result).isTrue();
+        verify(otpCacheService).invalidate("alice@example.com");
+        verify(notificationPort).send("alice@example.com", "999999");
+    }
+
+    // ── OtpVerificationResult messages ───────────────────────────────────────
+
+    @Test
+    void verificationResultMessages_areCorrect() {
+        assertThat(new OtpVerificationResult.Success().message())
+                .isEqualTo("OTP verified successfully");
+        assertThat(new OtpVerificationResult.Expired().message())
+                .contains("expired");
+        assertThat(new OtpVerificationResult.Invalid().message())
+                .isEqualTo("OTP is incorrect");
+        assertThat(new OtpVerificationResult.ServiceUnavailable().message())
+                .contains("unavailable");
+    }
+}


### PR DESCRIPTION
## Summary

Builds on FR-06's `OtpCacheService` (Redis store/TTL) to deliver the full OTP lifecycle.

- **`OtpNotificationPort`** — interface with a single `send(recipient, otp)` method; swap implementations per environment
- **`MockOtpNotificationAdapter`** — `@Profile("!prod")` adapter that logs OTP to console; production adapter is a future drop-in
- **`OtpVerificationResult`** — sealed interface with four permitted records:
  - `Success` — code matched, key consumed
  - `Expired` — Redis key gone (TTL = -2); distinct message from `Invalid`
  - `Invalid` — key present but code wrong
  - `ServiceUnavailable` — Redis unreachable
  Each record has `isSuccess()` and `message()` for clean controller use
- **`OtpService`**:
  - `sendOtp(recipient)` — generate → store → notify; notification failure is caught and logged, never blocks
  - `verify(recipient, otp)` — TTL peek → validateAndConsume → typed result
  - `resendOtp(recipient)` — invalidate existing → send fresh

## Test plan
- [ ] `sendOtp` — stores + notifies, Redis down → false + no notification, notification exception → still returns true
- [ ] `verify` — Success, Invalid, Expired (TTL=-2), ServiceUnavailable (Redis empty)
- [ ] `resendOtp` — calls invalidate then notifies with new code
- [ ] `OtpVerificationResult` messages match expected strings
- [ ] `MockOtpNotificationAdapter.send` — does not throw

