### PR TITLE
feat(backend): candidate registration API with OTP verification (FR-10)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/AuthController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AuthController.java
@@ -1,0 +1,54 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.auth.CandidateRegistrationRequest;
+import com.eaa.recruit.dto.auth.OtpVerificationRequest;
+import com.eaa.recruit.dto.auth.RegistrationResponse;
+import com.eaa.recruit.service.CandidateRegistrationService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final CandidateRegistrationService registrationService;
+
+    public AuthController(CandidateRegistrationService registrationService) {
+        this.registrationService = registrationService;
+    }
+
+    /**
+     * POST /api/v1/auth/register/candidate
+     *
+     * Accepts: fullName, email, password, phone
+     * Creates an INACTIVE candidate account and dispatches an OTP.
+     */
+    @PostMapping("/register/candidate")
+    public ResponseEntity<ApiResponse<RegistrationResponse>> registerCandidate(
+            @Valid @RequestBody CandidateRegistrationRequest request) {
+
+        RegistrationResponse response = registrationService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("Registration successful", response));
+    }
+
+    /**
+     * POST /api/v1/auth/verify-otp
+     *
+     * Accepts: email, otp
+     * Activates the account when OTP matches and has not expired.
+     */
+    @PostMapping("/verify-otp")
+    public ResponseEntity<ApiResponse<Void>> verifyOtp(
+            @Valid @RequestBody OtpVerificationRequest request) {
+
+        registrationService.verifyOtp(request.email(), request.otp());
+        return ResponseEntity.ok(ApiResponse.success("Account verified successfully"));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/CandidateRegistrationRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/CandidateRegistrationRequest.java
@@ -1,0 +1,25 @@
+package com.eaa.recruit.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CandidateRegistrationRequest(
+
+        @NotBlank(message = "Full name is required")
+        @Size(min = 2, max = 100, message = "Full name must be 2-100 characters")
+        String fullName,
+
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be valid")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, max = 72, message = "Password must be 8-72 characters")
+        String password,
+
+        @NotBlank(message = "Phone number is required")
+        @Pattern(regexp = "^\\+?[0-9]{7,15}$", message = "Phone number must be 7-15 digits")
+        String phone
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/OtpVerificationRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/OtpVerificationRequest.java
@@ -1,0 +1,16 @@
+package com.eaa.recruit.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record OtpVerificationRequest(
+
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be valid")
+        String email,
+
+        @NotBlank(message = "OTP is required")
+        @Pattern(regexp = "\\d{6}", message = "OTP must be exactly 6 digits")
+        String otp
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/RegistrationResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/RegistrationResponse.java
@@ -1,0 +1,7 @@
+package com.eaa.recruit.dto.auth;
+
+public record RegistrationResponse(
+        Long userId,
+        String email,
+        String message
+) {}

--- a/backend/src/main/java/com/eaa/recruit/service/CandidateRegistrationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/CandidateRegistrationService.java
@@ -1,0 +1,87 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.auth.CandidateRegistrationRequest;
+import com.eaa.recruit.dto.auth.RegistrationResponse;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.otp.OtpService;
+import com.eaa.recruit.otp.OtpVerificationResult;
+import com.eaa.recruit.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CandidateRegistrationService {
+
+    private static final Logger log = LoggerFactory.getLogger(CandidateRegistrationService.class);
+
+    private final UserRepository   userRepository;
+    private final PasswordEncoder  passwordEncoder;
+    private final OtpService       otpService;
+
+    public CandidateRegistrationService(UserRepository userRepository,
+                                        PasswordEncoder passwordEncoder,
+                                        OtpService otpService) {
+        this.userRepository  = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.otpService      = otpService;
+    }
+
+    /**
+     * Registers a new candidate account in INACTIVE state and dispatches an OTP.
+     *
+     * @throws ConflictException if email already exists
+     * @throws BusinessException if OTP dispatch fails (Redis / notification unavailable)
+     */
+    @Transactional
+    public RegistrationResponse register(CandidateRegistrationRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new ConflictException("Email is already registered: " + request.email());
+        }
+
+        String passwordHash = passwordEncoder.encode(request.password());
+        User user = User.create(request.email(), passwordHash, Role.CANDIDATE, request.fullName());
+        user = userRepository.save(user);
+
+        log.info("Candidate account created id={} email='{}'", user.getId(), user.getEmail());
+
+        // Send OTP to email; phone support is future work
+        boolean sent = otpService.sendOtp(request.email());
+        if (!sent) {
+            // Roll back the user row — can't leave an INACTIVE account with no way to verify
+            throw new BusinessException(
+                    "Registration failed: could not send verification code. Please try again.");
+        }
+
+        return new RegistrationResponse(
+                user.getId(),
+                user.getEmail(),
+                "Registration successful. A verification code has been sent to " + request.email()
+        );
+    }
+
+    /**
+     * Verifies the OTP and activates the candidate account.
+     *
+     * @throws BusinessException for expired / invalid / unavailable OTP
+     */
+    @Transactional
+    public void verifyOtp(String email, String otp) {
+        OtpVerificationResult result = otpService.verify(email, otp);
+
+        if (!result.isSuccess()) {
+            throw new BusinessException(result.message());
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException("Account not found for email: " + email));
+
+        user.activate();
+        log.info("Candidate account activated id={} email='{}'", user.getId(), email);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/AuthControllerTest.java
@@ -1,0 +1,170 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.config.SecurityConfig;
+import com.eaa.recruit.dto.auth.RegistrationResponse;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.GlobalExceptionHandler;
+import com.eaa.recruit.security.JwtAccessDeniedHandler;
+import com.eaa.recruit.security.JwtAuthEntryPoint;
+import com.eaa.recruit.security.JwtAuthenticationFilter;
+import com.eaa.recruit.security.JwtProperties;
+import com.eaa.recruit.security.JwtTokenProvider;
+import com.eaa.recruit.security.UserDetailsServiceImpl;
+import com.eaa.recruit.service.CandidateRegistrationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class,
+         JwtAuthenticationFilter.class, JwtTokenProvider.class,
+         JwtProperties.class, JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class AuthControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean  CandidateRegistrationService registrationService;
+    @MockBean  UserDetailsServiceImpl userDetailsService;
+
+    private static final String VALID_BODY = """
+            {
+              "fullName": "Alice Smith",
+              "email": "alice@example.com",
+              "password": "secret123",
+              "phone": "+601234567890"
+            }
+            """;
+
+    // ── POST /register/candidate ──────────────────────────────────────────────
+
+    @Test
+    void register_returns201_onSuccess() throws Exception {
+        when(registrationService.register(any()))
+                .thenReturn(new RegistrationResponse(1L, "alice@example.com",
+                        "Registration successful. A verification code has been sent to alice@example.com"));
+
+        mockMvc.perform(post("/api/v1/auth/register/candidate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+               .andExpect(status().isCreated())
+               .andExpect(jsonPath("$.status").value("success"))
+               .andExpect(jsonPath("$.data.email").value("alice@example.com"))
+               .andExpect(jsonPath("$.data.userId").value(1));
+    }
+
+    @Test
+    void register_returns409_onDuplicateEmail() throws Exception {
+        when(registrationService.register(any()))
+                .thenThrow(new ConflictException("Email is already registered: alice@example.com"));
+
+        mockMvc.perform(post("/api/v1/auth/register/candidate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+               .andExpect(status().isConflict())
+               .andExpect(jsonPath("$.status").value("error"))
+               .andExpect(jsonPath("$.message").value("Email is already registered: alice@example.com"));
+    }
+
+    @Test
+    void register_returns400_onMissingFields() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register/candidate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.status").value("error"))
+               .andExpect(jsonPath("$.errors").isArray());
+    }
+
+    @Test
+    void register_returns400_onInvalidEmail() throws Exception {
+        String body = """
+                {"fullName":"Alice","email":"not-an-email","password":"secret123","phone":"+601234567"}
+                """;
+        mockMvc.perform(post("/api/v1/auth/register/candidate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.errors[?(@.field=='email')]").exists());
+    }
+
+    @Test
+    void register_returns400_onShortPassword() throws Exception {
+        String body = """
+                {"fullName":"Alice","email":"alice@example.com","password":"short","phone":"+601234567"}
+                """;
+        mockMvc.perform(post("/api/v1/auth/register/candidate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.errors[?(@.field=='password')]").exists());
+    }
+
+    @Test
+    void register_returns400_onOtpDispatchFailure() throws Exception {
+        when(registrationService.register(any()))
+                .thenThrow(new BusinessException("Registration failed: could not send verification code"));
+
+        mockMvc.perform(post("/api/v1/auth/register/candidate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.message").value("Registration failed: could not send verification code"));
+    }
+
+    // ── POST /verify-otp ──────────────────────────────────────────────────────
+
+    @Test
+    void verifyOtp_returns200_onSuccess() throws Exception {
+        doNothing().when(registrationService).verifyOtp("alice@example.com", "123456");
+
+        mockMvc.perform(post("/api/v1/auth/verify-otp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email":"alice@example.com","otp":"123456"}
+                                """))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.status").value("success"))
+               .andExpect(jsonPath("$.message").value("Account verified successfully"));
+    }
+
+    @Test
+    void verifyOtp_returns400_onExpiredOtp() throws Exception {
+        doThrow(new BusinessException("OTP has expired. Please request a new one"))
+                .when(registrationService).verifyOtp("alice@example.com", "123456");
+
+        mockMvc.perform(post("/api/v1/auth/verify-otp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email":"alice@example.com","otp":"123456"}
+                                """))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.message").value("OTP has expired. Please request a new one"));
+    }
+
+    @Test
+    void verifyOtp_returns400_onInvalidOtpFormat() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/verify-otp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email":"alice@example.com","otp":"abc"}
+                                """))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.errors[?(@.field=='otp')]").exists());
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/CandidateRegistrationServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/CandidateRegistrationServiceTest.java
@@ -1,0 +1,144 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.auth.CandidateRegistrationRequest;
+import com.eaa.recruit.dto.auth.RegistrationResponse;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.otp.OtpService;
+import com.eaa.recruit.otp.OtpVerificationResult;
+import com.eaa.recruit.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CandidateRegistrationServiceTest {
+
+    @Mock UserRepository   userRepository;
+    @Mock PasswordEncoder  passwordEncoder;
+    @Mock OtpService       otpService;
+
+    CandidateRegistrationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CandidateRegistrationService(userRepository, passwordEncoder, otpService);
+    }
+
+    private static CandidateRegistrationRequest validRequest() {
+        return new CandidateRegistrationRequest(
+                "Alice Smith", "alice@example.com", "secret123", "+601234567890");
+    }
+
+    private static User savedUser() {
+        return User.create("alice@example.com", "$2a$hashed", Role.CANDIDATE, "Alice Smith");
+    }
+
+    // ── register ─────────────────────────────────────────────────────────────
+
+    @Test
+    void register_createsInactiveUser_andSendsOtp() {
+        when(userRepository.existsByEmail("alice@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("secret123")).thenReturn("$2a$hashed");
+        when(userRepository.save(any(User.class))).thenReturn(savedUser());
+        when(otpService.sendOtp("alice@example.com")).thenReturn(true);
+
+        RegistrationResponse response = service.register(validRequest());
+
+        assertThat(response.email()).isEqualTo("alice@example.com");
+        assertThat(response.message()).contains("verification code");
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().isActive()).isFalse();
+        assertThat(captor.getValue().getRole()).isEqualTo(Role.CANDIDATE);
+        assertThat(captor.getValue().getPasswordHash()).isEqualTo("$2a$hashed");
+    }
+
+    @Test
+    void register_throwsConflict_onDuplicateEmail() {
+        when(userRepository.existsByEmail("alice@example.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.register(validRequest()))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("already registered");
+
+        verifyNoInteractions(passwordEncoder, otpService);
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void register_throwsBusiness_whenOtpFails() {
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        when(passwordEncoder.encode(anyString())).thenReturn("$2a$hashed");
+        when(userRepository.save(any())).thenReturn(savedUser());
+        when(otpService.sendOtp(anyString())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.register(validRequest()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("could not send verification code");
+    }
+
+    @Test
+    void register_passwordIsHashed_neverPlaintext() {
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        when(passwordEncoder.encode("secret123")).thenReturn("$2a$10$bcrypt");
+        when(userRepository.save(any())).thenReturn(savedUser());
+        when(otpService.sendOtp(anyString())).thenReturn(true);
+
+        service.register(validRequest());
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getPasswordHash()).isNotEqualTo("secret123");
+        assertThat(captor.getValue().getPasswordHash()).startsWith("$2a$");
+    }
+
+    // ── verifyOtp ─────────────────────────────────────────────────────────────
+
+    @Test
+    void verifyOtp_activatesAccount_onSuccess() {
+        User user = savedUser();
+        when(otpService.verify("alice@example.com", "123456"))
+                .thenReturn(new OtpVerificationResult.Success());
+        when(userRepository.findByEmail("alice@example.com")).thenReturn(Optional.of(user));
+
+        service.verifyOtp("alice@example.com", "123456");
+
+        assertThat(user.isActive()).isTrue();
+    }
+
+    @Test
+    void verifyOtp_throwsBusiness_whenExpired() {
+        when(otpService.verify("alice@example.com", "123456"))
+                .thenReturn(new OtpVerificationResult.Expired());
+
+        assertThatThrownBy(() -> service.verifyOtp("alice@example.com", "123456"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("expired");
+    }
+
+    @Test
+    void verifyOtp_throwsBusiness_whenInvalid() {
+        when(otpService.verify("alice@example.com", "000000"))
+                .thenReturn(new OtpVerificationResult.Invalid());
+
+        assertThatThrownBy(() -> service.verifyOtp("alice@example.com", "000000"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("incorrect");
+    }
+}


### PR DESCRIPTION
## Summary

- **`CandidateRegistrationRequest`** — validated record: `fullName` (2-100 chars), `email` (format), `password` (8-72 chars), `phone` (7-15 digit pattern)
- **`OtpVerificationRequest`** — validated record: `email` + `otp` (`\d{6}` pattern)
- **`RegistrationResponse`** — `{ userId, email, message }`
- **`CandidateRegistrationService`**:
  - `register()` — duplicate email → 409; BCrypt hash; save INACTIVE `User`; `OtpService.sendOtp()` → rolls back on failure
  - `verifyOtp()` — delegates to `OtpService.verify()`; maps `Success` to account activation; maps `Expired/Invalid/ServiceUnavailable` to `BusinessException`
- **`AuthController`** at `/api/v1/auth` (public, no JWT required):
  - `POST /register/candidate` → 201 on success
  - `POST /verify-otp` → 200 on success

## Endpoints

| Method | Path | Auth | Success |
|--------|------|------|---------|
| POST | `/api/v1/auth/register/candidate` | Public | 201 |
| POST | `/api/v1/auth/verify-otp` | Public | 200 |

## Test plan
- [ ] `CandidateRegistrationServiceTest` — success flow, duplicate email 409, OTP dispatch failure, password hashing, OTP expiry 400, OTP mismatch 400
- [ ] `AuthControllerTest` — 201 success, 409 duplicate, 400 empty body (field errors array), 400 invalid email, 400 short password, 400 OTP dispatch fail, 200 verify success, 400 expired OTP, 400 invalid OTP format

