### PR TITLE
feat(backend): recruiter account creation API (FR-11)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/AdminUserController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AdminUserController.java
@@ -1,0 +1,39 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.admin.CreateRecruiterRequest;
+import com.eaa.recruit.dto.admin.RecruiterCreatedResponse;
+import com.eaa.recruit.security.rbac.IsAdmin;
+import com.eaa.recruit.service.RecruiterAdminService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@IsAdmin
+public class AdminUserController {
+
+    private final RecruiterAdminService recruiterAdminService;
+
+    public AdminUserController(RecruiterAdminService recruiterAdminService) {
+        this.recruiterAdminService = recruiterAdminService;
+    }
+
+    /**
+     * POST /api/v1/admin/users/recruiter
+     * Accessible to ADMIN and SUPER_ADMIN only.
+     */
+    @PostMapping("/recruiter")
+    public ResponseEntity<ApiResponse<RecruiterCreatedResponse>> createRecruiter(
+            @Valid @RequestBody CreateRecruiterRequest request) {
+
+        RecruiterCreatedResponse response = recruiterAdminService.createRecruiter(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("Recruiter account created successfully", response));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/CreateRecruiterRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/CreateRecruiterRequest.java
@@ -1,0 +1,20 @@
+package com.eaa.recruit.dto.admin;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateRecruiterRequest(
+
+        @NotBlank(message = "Full name is required")
+        @Size(min = 2, max = 100, message = "Full name must be 2-100 characters")
+        String fullName,
+
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be valid")
+        String email,
+
+        @NotBlank(message = "Temporary password is required")
+        @Size(min = 8, max = 72, message = "Temporary password must be 8-72 characters")
+        String temporaryPassword
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/RecruiterCreatedResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/RecruiterCreatedResponse.java
@@ -1,0 +1,8 @@
+package com.eaa.recruit.dto.admin;
+
+public record RecruiterCreatedResponse(
+        Long   userId,
+        String email,
+        String fullName,
+        String message
+) {}

--- a/backend/src/main/java/com/eaa/recruit/notification/MockWelcomeNotificationAdapter.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/MockWelcomeNotificationAdapter.java
@@ -1,0 +1,26 @@
+package com.eaa.recruit.notification;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mock welcome email adapter for dev/test environments.
+ * Logs credentials to console instead of sending a real email.
+ */
+@Component
+@Profile("!prod")
+public class MockWelcomeNotificationAdapter implements WelcomeNotificationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockWelcomeNotificationAdapter.class);
+
+    @Override
+    public void sendRecruiterWelcome(String email, String fullName, String temporaryPassword) {
+        log.info("╔══════════════════════════════════════════╗");
+        log.info("║  [MOCK WELCOME]  To       : {}", email);
+        log.info("║  [MOCK WELCOME]  Name     : {}", fullName);
+        log.info("║  [MOCK WELCOME]  Password : {}", temporaryPassword);
+        log.info("╚══════════════════════════════════════════╝");
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/notification/WelcomeNotificationPort.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/WelcomeNotificationPort.java
@@ -1,0 +1,15 @@
+package com.eaa.recruit.notification;
+
+/**
+ * Port for sending welcome emails to newly created recruiter accounts.
+ * Swap implementation per environment (mock in dev, real SMTP in prod).
+ */
+public interface WelcomeNotificationPort {
+
+    /**
+     * @param email             recipient email address
+     * @param fullName          recipient full name
+     * @param temporaryPassword the plain-text temporary password (before hashing)
+     */
+    void sendRecruiterWelcome(String email, String fullName, String temporaryPassword);
+}

--- a/backend/src/main/java/com/eaa/recruit/service/RecruiterAdminService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/RecruiterAdminService.java
@@ -1,0 +1,72 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.admin.CreateRecruiterRequest;
+import com.eaa.recruit.dto.admin.RecruiterCreatedResponse;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.notification.WelcomeNotificationPort;
+import com.eaa.recruit.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RecruiterAdminService {
+
+    private static final Logger log = LoggerFactory.getLogger(RecruiterAdminService.class);
+
+    private final UserRepository          userRepository;
+    private final PasswordEncoder         passwordEncoder;
+    private final WelcomeNotificationPort welcomeNotification;
+
+    public RecruiterAdminService(UserRepository userRepository,
+                                 PasswordEncoder passwordEncoder,
+                                 WelcomeNotificationPort welcomeNotification) {
+        this.userRepository      = userRepository;
+        this.passwordEncoder     = passwordEncoder;
+        this.welcomeNotification = welcomeNotification;
+    }
+
+    /**
+     * Creates a new ACTIVE recruiter account.
+     * Only callable by ADMIN or SUPER_ADMIN (enforced at controller via @IsAdmin).
+     *
+     * @throws ConflictException if email is already registered
+     */
+    @Transactional
+    public RecruiterCreatedResponse createRecruiter(CreateRecruiterRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new ConflictException("Email is already registered: " + request.email());
+        }
+
+        String hash = passwordEncoder.encode(request.temporaryPassword());
+        User recruiter = User.create(request.email(), hash, Role.RECRUITER, request.fullName());
+        // Recruiters are created ACTIVE — no OTP needed, admin-vetted
+        recruiter.activate();
+        recruiter = userRepository.save(recruiter);
+
+        log.info("Recruiter account created id={} email='{}'", recruiter.getId(), recruiter.getEmail());
+
+        try {
+            welcomeNotification.sendRecruiterWelcome(
+                    recruiter.getEmail(),
+                    recruiter.getFullName(),
+                    request.temporaryPassword()   // plain-text before hashing for the welcome email
+            );
+        } catch (Exception ex) {
+            log.error("Welcome notification failed for recruiter email='{}': {}",
+                    recruiter.getEmail(), ex.getMessage(), ex);
+            // Non-fatal — account is created; admin can resend manually
+        }
+
+        return new RecruiterCreatedResponse(
+                recruiter.getId(),
+                recruiter.getEmail(),
+                recruiter.getFullName(),
+                "Recruiter account created successfully"
+        );
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/controller/AdminUserControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/AdminUserControllerTest.java
@@ -1,0 +1,148 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.config.SecurityConfig;
+import com.eaa.recruit.dto.admin.RecruiterCreatedResponse;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.GlobalExceptionHandler;
+import com.eaa.recruit.security.*;
+import com.eaa.recruit.service.RecruiterAdminService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminUserController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class,
+         JwtAuthenticationFilter.class, JwtTokenProvider.class,
+         JwtProperties.class, JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class AdminUserControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean  RecruiterAdminService recruiterAdminService;
+    @MockBean  UserDetailsServiceImpl userDetailsService;
+
+    private static final String VALID_BODY = """
+            {
+              "fullName": "Bob Jones",
+              "email": "bob@example.com",
+              "temporaryPassword": "TempPass1!"
+            }
+            """;
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/users/recruiter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+               .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "CANDIDATE")
+    void candidate_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/users/recruiter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+               .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void recruiter_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/users/recruiter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+               .andExpect(status().isForbidden());
+    }
+
+    // ── Success ───────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void admin_returns201_onSuccess() throws Exception {
+        when(recruiterAdminService.createRecruiter(any()))
+                .thenReturn(new RecruiterCreatedResponse(
+                        5L, "bob@example.com", "Bob Jones",
+                        "Recruiter account created successfully"));
+
+        mockMvc.perform(post("/api/v1/admin/users/recruiter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+               .andExpect(status().isCreated())
+               .andExpect(jsonPath("$.status").value("success"))
+               .andExpect(jsonPath("$.data.userId").value(5))
+               .andExpect(jsonPath("$.data.email").value("bob@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "SUPER_ADMIN")
+    void superAdmin_returns201_onSuccess() throws Exception {
+        when(recruiterAdminService.createRecruiter(any()))
+                .thenReturn(new RecruiterCreatedResponse(
+                        6L, "bob2@example.com", "Bob Two",
+                        "Recruiter account created successfully"));
+
+        mockMvc.perform(post("/api/v1/admin/users/recruiter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"fullName":"Bob Two","email":"bob2@example.com","temporaryPassword":"TempPass1!"}
+                                """))
+               .andExpect(status().isCreated())
+               .andExpect(jsonPath("$.data.userId").value(6));
+    }
+
+    // ── Error cases ───────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void admin_returns409_onDuplicateEmail() throws Exception {
+        when(recruiterAdminService.createRecruiter(any()))
+                .thenThrow(new ConflictException("Email is already registered: bob@example.com"));
+
+        mockMvc.perform(post("/api/v1/admin/users/recruiter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+               .andExpect(status().isConflict())
+               .andExpect(jsonPath("$.message").value("Email is already registered: bob@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void admin_returns400_onMissingFields() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/users/recruiter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.errors").isArray());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void admin_returns400_onInvalidEmail() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/users/recruiter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"fullName":"Bob","email":"not-email","temporaryPassword":"TempPass1!"}
+                                """))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.errors[?(@.field=='email')]").exists());
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/RecruiterAdminServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/RecruiterAdminServiceTest.java
@@ -1,0 +1,105 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.admin.CreateRecruiterRequest;
+import com.eaa.recruit.dto.admin.RecruiterCreatedResponse;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.notification.WelcomeNotificationPort;
+import com.eaa.recruit.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecruiterAdminServiceTest {
+
+    @Mock UserRepository          userRepository;
+    @Mock PasswordEncoder         passwordEncoder;
+    @Mock WelcomeNotificationPort welcomeNotification;
+
+    RecruiterAdminService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RecruiterAdminService(userRepository, passwordEncoder, welcomeNotification);
+    }
+
+    private static CreateRecruiterRequest validRequest() {
+        return new CreateRecruiterRequest("Bob Jones", "bob@example.com", "TempPass1!");
+    }
+
+    private static User savedRecruiter() {
+        User u = User.create("bob@example.com", "$2a$hashed", Role.RECRUITER, "Bob Jones");
+        u.activate();
+        return u;
+    }
+
+    @Test
+    void createRecruiter_createsActiveRecruiter_andSendsWelcome() {
+        when(userRepository.existsByEmail("bob@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("TempPass1!")).thenReturn("$2a$hashed");
+        when(userRepository.save(any(User.class))).thenReturn(savedRecruiter());
+
+        RecruiterCreatedResponse resp = service.createRecruiter(validRequest());
+
+        assertThat(resp.email()).isEqualTo("bob@example.com");
+        assertThat(resp.fullName()).isEqualTo("Bob Jones");
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().isActive()).isTrue();
+        assertThat(captor.getValue().getRole()).isEqualTo(Role.RECRUITER);
+        assertThat(captor.getValue().getPasswordHash()).isEqualTo("$2a$hashed");
+
+        verify(welcomeNotification).sendRecruiterWelcome("bob@example.com", "Bob Jones", "TempPass1!");
+    }
+
+    @Test
+    void createRecruiter_throwsConflict_onDuplicateEmail() {
+        when(userRepository.existsByEmail("bob@example.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.createRecruiter(validRequest()))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("already registered");
+
+        verify(userRepository, never()).save(any());
+        verifyNoInteractions(welcomeNotification);
+    }
+
+    @Test
+    void createRecruiter_stillSucceeds_whenWelcomeNotificationFails() {
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        when(passwordEncoder.encode(anyString())).thenReturn("$2a$hashed");
+        when(userRepository.save(any())).thenReturn(savedRecruiter());
+        doThrow(new RuntimeException("SMTP down"))
+                .when(welcomeNotification).sendRecruiterWelcome(anyString(), anyString(), anyString());
+
+        // Should not throw — notification failure is non-fatal
+        RecruiterCreatedResponse resp = service.createRecruiter(validRequest());
+        assertThat(resp.email()).isEqualTo("bob@example.com");
+    }
+
+    @Test
+    void createRecruiter_passwordIsHashed() {
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        when(passwordEncoder.encode("TempPass1!")).thenReturn("$2a$10$bcrypt");
+        when(userRepository.save(any())).thenReturn(savedRecruiter());
+
+        service.createRecruiter(validRequest());
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getPasswordHash()).isNotEqualTo("TempPass1!");
+    }
+}


### PR DESCRIPTION
## Summary

- **`CreateRecruiterRequest`** — validated record: `fullName`, `email`, `temporaryPassword` (8-72 chars)
- **`RecruiterCreatedResponse`** — `{ userId, email, fullName, message }`
- **`WelcomeNotificationPort`** — `sendRecruiterWelcome(email, fullName, temporaryPassword)` interface
- **`MockWelcomeNotificationAdapter`** — `@Profile("!prod")` logs credentials to console
- **`RecruiterAdminService`** — conflict check → hash → create ACTIVE RECRUITER → save → welcome notification (non-fatal on failure)
- **`AdminUserController`** — `@IsAdmin` at class level restricts all routes; `POST /api/v1/admin/users/recruiter` → 201

## Endpoint

| Method | Path | Roles | Success |
|--------|------|-------|---------|
| POST | `/api/v1/admin/users/recruiter` | ADMIN, SUPER_ADMIN | 201 |

## Test plan
- [ ] `RecruiterAdminServiceTest` — success (active, RECRUITER role, hashed pw, welcome sent), duplicate 409, welcome failure non-fatal, password never plaintext
- [ ] `AdminUserControllerTest` — unauthenticated 401, CANDIDATE 403, RECRUITER 403, ADMIN 201, SUPER_ADMIN 201, duplicate 409, missing fields 400 with errors array, invalid email 400

