### PR TITLE
feat(backend): user activation/deactivation with Redis blocked-user list (FR-12)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,12 @@
       "Bash(python -c ':*)",
       "Bash(gh project:*)",
       "Bash(python:*)",
-      "Bash(pip install:*)"
+      "Bash(pip install:*)",
+      "Bash(git checkout:*)",
+      "Bash(gh pr *)",
+      "Bash(git rebase *)",
+      "Bash(GIT_EDITOR=true git rebase *)",
+      "Bash(git add *)"
     ]
   }
 }

--- a/backend/src/main/java/com/eaa/recruit/cache/BlockedUserCacheService.java
+++ b/backend/src/main/java/com/eaa/recruit/cache/BlockedUserCacheService.java
@@ -1,0 +1,67 @@
+package com.eaa.recruit.cache;
+
+import com.eaa.recruit.security.JwtProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+/**
+ * Tracks deactivated user IDs in Redis so that valid JWTs are immediately
+ * rejected without waiting for token expiry.
+ *
+ * Key schema : blocked_user:{userId}
+ * TTL        : jwt.expiration-ms  (key auto-evicts once no live token can exist)
+ */
+@Service
+public class BlockedUserCacheService {
+
+    private static final Logger log = LoggerFactory.getLogger(BlockedUserCacheService.class);
+    private static final String KEY_PREFIX = "blocked_user:";
+
+    private final StringRedisTemplate redis;
+    private final JwtProperties       jwtProperties;
+
+    public BlockedUserCacheService(StringRedisTemplate redis, JwtProperties jwtProperties) {
+        this.redis         = redis;
+        this.jwtProperties = jwtProperties;
+    }
+
+    /** Marks a user as blocked for the lifetime of any currently-valid JWT. */
+    public void block(Long userId) {
+        try {
+            Duration ttl = Duration.ofMillis(jwtProperties.getExpirationMs());
+            redis.opsForValue().set(KEY_PREFIX + userId, "1", ttl);
+            log.info("User id={} added to blocked list (ttl={}ms)", userId, jwtProperties.getExpirationMs());
+        } catch (DataAccessException ex) {
+            log.error("Redis unavailable — could not block user id={}: {}", userId, ex.getMessage(), ex);
+        }
+    }
+
+    /** Removes a user from the blocked list (restores access). */
+    public void unblock(Long userId) {
+        try {
+            redis.delete(KEY_PREFIX + userId);
+            log.info("User id={} removed from blocked list", userId);
+        } catch (DataAccessException ex) {
+            log.error("Redis unavailable — could not unblock user id={}: {}", userId, ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Returns true if the user is blocked.
+     * Fails open (returns false) when Redis is unavailable — existing tokens
+     * remain usable rather than causing an outage. Logged as a warning.
+     */
+    public boolean isBlocked(Long userId) {
+        try {
+            return Boolean.TRUE.equals(redis.hasKey(KEY_PREFIX + userId));
+        } catch (DataAccessException ex) {
+            log.warn("Redis unavailable — cannot verify block status for user id={}, failing open", userId);
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/AdminUserController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AdminUserController.java
@@ -3,15 +3,16 @@ package com.eaa.recruit.controller;
 import com.eaa.recruit.dto.ApiResponse;
 import com.eaa.recruit.dto.admin.CreateRecruiterRequest;
 import com.eaa.recruit.dto.admin.RecruiterCreatedResponse;
+import com.eaa.recruit.dto.admin.UserStatusRequest;
+import com.eaa.recruit.security.AuthenticatedUser;
 import com.eaa.recruit.security.rbac.IsAdmin;
 import com.eaa.recruit.service.RecruiterAdminService;
+import com.eaa.recruit.service.UserStatusService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/admin/users")
@@ -19,14 +20,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminUserController {
 
     private final RecruiterAdminService recruiterAdminService;
+    private final UserStatusService     userStatusService;
 
-    public AdminUserController(RecruiterAdminService recruiterAdminService) {
+    public AdminUserController(RecruiterAdminService recruiterAdminService,
+                               UserStatusService userStatusService) {
         this.recruiterAdminService = recruiterAdminService;
+        this.userStatusService     = userStatusService;
     }
 
     /**
      * POST /api/v1/admin/users/recruiter
-     * Accessible to ADMIN and SUPER_ADMIN only.
+     * Creates an ACTIVE recruiter account. ADMIN + SUPER_ADMIN only.
      */
     @PostMapping("/recruiter")
     public ResponseEntity<ApiResponse<RecruiterCreatedResponse>> createRecruiter(
@@ -35,5 +39,23 @@ public class AdminUserController {
         RecruiterCreatedResponse response = recruiterAdminService.createRecruiter(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("Recruiter account created successfully", response));
+    }
+
+    /**
+     * PATCH /api/v1/admin/users/{id}/status
+     * Activates or deactivates any user. Takes effect immediately.
+     * Admins cannot deactivate SUPER_ADMIN accounts.
+     */
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<ApiResponse<Void>> setUserStatus(
+            @PathVariable Long id,
+            @Valid @RequestBody UserStatusRequest request,
+            @AuthenticationPrincipal AuthenticatedUser requester) {
+
+        userStatusService.setStatus(id, request.active(), requester);
+        String msg = Boolean.TRUE.equals(request.active())
+                ? "User activated successfully"
+                : "User deactivated successfully";
+        return ResponseEntity.ok(ApiResponse.success(msg));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/CreateRecruiterRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/CreateRecruiterRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record CreateRecruiterRequest(
-
         @NotBlank(message = "Full name is required")
         @Size(min = 2, max = 100, message = "Full name must be 2-100 characters")
         String fullName,

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/UserStatusRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/UserStatusRequest.java
@@ -1,0 +1,8 @@
+package com.eaa.recruit.dto.admin;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserStatusRequest(
+        @NotNull(message = "active field is required")
+        Boolean active
+) {}

--- a/backend/src/main/java/com/eaa/recruit/notification/MockWelcomeNotificationAdapter.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/MockWelcomeNotificationAdapter.java
@@ -5,10 +5,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-/**
- * Mock welcome email adapter for dev/test environments.
- * Logs credentials to console instead of sending a real email.
- */
 @Component
 @Profile("!prod")
 public class MockWelcomeNotificationAdapter implements WelcomeNotificationPort {

--- a/backend/src/main/java/com/eaa/recruit/notification/WelcomeNotificationPort.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/WelcomeNotificationPort.java
@@ -1,15 +1,5 @@
 package com.eaa.recruit.notification;
 
-/**
- * Port for sending welcome emails to newly created recruiter accounts.
- * Swap implementation per environment (mock in dev, real SMTP in prod).
- */
 public interface WelcomeNotificationPort {
-
-    /**
-     * @param email             recipient email address
-     * @param fullName          recipient full name
-     * @param temporaryPassword the plain-text temporary password (before hashing)
-     */
     void sendRecruiterWelcome(String email, String fullName, String temporaryPassword);
 }

--- a/backend/src/main/java/com/eaa/recruit/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/eaa/recruit/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.eaa.recruit.security;
 
+import com.eaa.recruit.cache.BlockedUserCacheService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,10 +21,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String BEARER_PREFIX = "Bearer ";
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider        jwtTokenProvider;
+    private final BlockedUserCacheService blockedUserCache;
 
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
+                                   BlockedUserCacheService blockedUserCache) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.blockedUserCache = blockedUserCache;
     }
 
     @Override
@@ -33,12 +37,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-            String email  = jwtTokenProvider.extractEmail(token);
             Long   userId = jwtTokenProvider.extractUserId(token);
+            String email  = jwtTokenProvider.extractEmail(token);
             String role   = jwtTokenProvider.extractRole(token);
 
+            // Immediately reject tokens belonging to deactivated users
+            if (blockedUserCache.isBlocked(userId)) {
+                chain.doFilter(request, response);
+                return;
+            }
+
             AuthenticatedUser principal = new AuthenticatedUser(userId, email, role);
-            List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+            List<SimpleGrantedAuthority> authorities =
+                    List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
             UsernamePasswordAuthenticationToken auth =
                     new UsernamePasswordAuthenticationToken(principal, null, authorities);

--- a/backend/src/main/java/com/eaa/recruit/service/RecruiterAdminService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/RecruiterAdminService.java
@@ -25,17 +25,11 @@ public class RecruiterAdminService {
     public RecruiterAdminService(UserRepository userRepository,
                                  PasswordEncoder passwordEncoder,
                                  WelcomeNotificationPort welcomeNotification) {
-        this.userRepository      = userRepository;
-        this.passwordEncoder     = passwordEncoder;
+        this.userRepository     = userRepository;
+        this.passwordEncoder    = passwordEncoder;
         this.welcomeNotification = welcomeNotification;
     }
 
-    /**
-     * Creates a new ACTIVE recruiter account.
-     * Only callable by ADMIN or SUPER_ADMIN (enforced at controller via @IsAdmin).
-     *
-     * @throws ConflictException if email is already registered
-     */
     @Transactional
     public RecruiterCreatedResponse createRecruiter(CreateRecruiterRequest request) {
         if (userRepository.existsByEmail(request.email())) {
@@ -44,7 +38,6 @@ public class RecruiterAdminService {
 
         String hash = passwordEncoder.encode(request.temporaryPassword());
         User recruiter = User.create(request.email(), hash, Role.RECRUITER, request.fullName());
-        // Recruiters are created ACTIVE — no OTP needed, admin-vetted
         recruiter.activate();
         recruiter = userRepository.save(recruiter);
 
@@ -52,21 +45,14 @@ public class RecruiterAdminService {
 
         try {
             welcomeNotification.sendRecruiterWelcome(
-                    recruiter.getEmail(),
-                    recruiter.getFullName(),
-                    request.temporaryPassword()   // plain-text before hashing for the welcome email
-            );
+                    recruiter.getEmail(), recruiter.getFullName(), request.temporaryPassword());
         } catch (Exception ex) {
             log.error("Welcome notification failed for recruiter email='{}': {}",
                     recruiter.getEmail(), ex.getMessage(), ex);
-            // Non-fatal — account is created; admin can resend manually
         }
 
         return new RecruiterCreatedResponse(
-                recruiter.getId(),
-                recruiter.getEmail(),
-                recruiter.getFullName(),
-                "Recruiter account created successfully"
-        );
+                recruiter.getId(), recruiter.getEmail(),
+                recruiter.getFullName(), "Recruiter account created successfully");
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/service/UserStatusService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/UserStatusService.java
@@ -1,0 +1,63 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.cache.BlockedUserCacheService;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserStatusService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserStatusService.class);
+
+    private final UserRepository          userRepository;
+    private final BlockedUserCacheService blockedUserCache;
+
+    public UserStatusService(UserRepository userRepository,
+                             BlockedUserCacheService blockedUserCache) {
+        this.userRepository   = userRepository;
+        this.blockedUserCache = blockedUserCache;
+    }
+
+    /**
+     * Activates or deactivates a user account.
+     *
+     * Rules:
+     * - Target user must exist (404 otherwise)
+     * - Admins cannot deactivate SUPER_ADMIN accounts
+     * - Deactivation immediately blocks existing JWTs via Redis
+     * - Activation removes the Redis block
+     *
+     * @param targetId  ID of the user to update
+     * @param active    desired state
+     * @param requester the authenticated admin performing the action
+     */
+    @Transactional
+    public void setStatus(Long targetId, boolean active, AuthenticatedUser requester) {
+        User target = userRepository.findById(targetId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", targetId));
+
+        // Admins (non-super) cannot touch SUPER_ADMIN accounts
+        if (target.getRole() == Role.SUPER_ADMIN
+                && !requester.role().equals(Role.SUPER_ADMIN.name())) {
+            throw new BusinessException("Admins cannot modify Super Admin accounts");
+        }
+
+        if (active) {
+            target.activate();
+            blockedUserCache.unblock(targetId);
+            log.info("User id={} activated by admin id={}", targetId, requester.id());
+        } else {
+            target.deactivate();
+            blockedUserCache.block(targetId);
+            log.info("User id={} deactivated by admin id={}", targetId, requester.id());
+        }
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/cache/BlockedUserCacheServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/cache/BlockedUserCacheServiceTest.java
@@ -1,0 +1,80 @@
+package com.eaa.recruit.cache;
+
+import com.eaa.recruit.security.JwtProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BlockedUserCacheServiceTest {
+
+    @Mock StringRedisTemplate        redis;
+    @Mock ValueOperations<String, String> valueOps;
+
+    BlockedUserCacheService service;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties();
+        props.setExpirationMs(86_400_000L); // 24h
+        when(redis.opsForValue()).thenReturn(valueOps);
+        service = new BlockedUserCacheService(redis, props);
+    }
+
+    @Test
+    void block_setsKeyWithJwtTtl() {
+        service.block(42L);
+        verify(valueOps).set(eq("blocked_user:42"), eq("1"), eq(Duration.ofMillis(86_400_000L)));
+    }
+
+    @Test
+    void unblock_deletesKey() {
+        service.unblock(42L);
+        verify(redis).delete("blocked_user:42");
+    }
+
+    @Test
+    void isBlocked_trueWhenKeyPresent() {
+        when(redis.hasKey("blocked_user:42")).thenReturn(true);
+        assertThat(service.isBlocked(42L)).isTrue();
+    }
+
+    @Test
+    void isBlocked_falseWhenKeyAbsent() {
+        when(redis.hasKey("blocked_user:42")).thenReturn(false);
+        assertThat(service.isBlocked(42L)).isFalse();
+    }
+
+    @Test
+    void isBlocked_failsOpen_whenRedisDown() {
+        when(redis.hasKey(anyString()))
+                .thenThrow(new DataAccessResourceFailureException("Redis down"));
+        // fail open — should return false, not throw
+        assertThat(service.isBlocked(42L)).isFalse();
+    }
+
+    @Test
+    void block_doesNotThrow_whenRedisDown() {
+        doThrow(new DataAccessResourceFailureException("Redis down"))
+                .when(valueOps).set(anyString(), anyString(), any(Duration.class));
+        service.block(42L); // must not propagate
+    }
+
+    @Test
+    void unblock_doesNotThrow_whenRedisDown() {
+        doThrow(new DataAccessResourceFailureException("Redis down"))
+                .when(redis).delete(anyString());
+        service.unblock(42L); // must not propagate
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/controller/AdminUserStatusControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/AdminUserStatusControllerTest.java
@@ -1,0 +1,128 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.config.SecurityConfig;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.GlobalExceptionHandler;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.security.*;
+import com.eaa.recruit.service.RecruiterAdminService;
+import com.eaa.recruit.service.UserStatusService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminUserController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class,
+         JwtAuthenticationFilter.class, JwtTokenProvider.class,
+         JwtProperties.class, JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class AdminUserStatusControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean  UserStatusService       userStatusService;
+    @MockBean  RecruiterAdminService   recruiterAdminService;
+    @MockBean  UserDetailsServiceImpl  userDetailsService;
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void unauthenticated_returns401() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin/users/10/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"active\":false}"))
+               .andExpect(status().isUnauthorized());
+    }
+
+    @Test @WithMockUser(roles = "CANDIDATE")
+    void candidate_returns403() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin/users/10/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"active\":false}"))
+               .andExpect(status().isForbidden());
+    }
+
+    @Test @WithMockUser(roles = "RECRUITER")
+    void recruiter_returns403() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin/users/10/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"active\":false}"))
+               .andExpect(status().isForbidden());
+    }
+
+    // ── Deactivate ────────────────────────────────────────────────────────────
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void admin_deactivate_returns200() throws Exception {
+        doNothing().when(userStatusService).setStatus(anyLong(), eq(false), any());
+
+        mockMvc.perform(patch("/api/v1/admin/users/10/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"active\":false}"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.status").value("success"))
+               .andExpect(jsonPath("$.message").value("User deactivated successfully"));
+    }
+
+    // ── Activate ──────────────────────────────────────────────────────────────
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void admin_activate_returns200() throws Exception {
+        doNothing().when(userStatusService).setStatus(anyLong(), eq(true), any());
+
+        mockMvc.perform(patch("/api/v1/admin/users/10/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"active\":true}"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.message").value("User activated successfully"));
+    }
+
+    // ── Error cases ───────────────────────────────────────────────────────────
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void returns404_whenUserNotFound() throws Exception {
+        doThrow(new ResourceNotFoundException("User", 999L))
+                .when(userStatusService).setStatus(eq(999L), anyBoolean(), any());
+
+        mockMvc.perform(patch("/api/v1/admin/users/999/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"active\":false}"))
+               .andExpect(status().isNotFound());
+    }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void returns400_whenDeactivatingSuperAdmin() throws Exception {
+        doThrow(new BusinessException("Admins cannot modify Super Admin accounts"))
+                .when(userStatusService).setStatus(anyLong(), anyBoolean(), any());
+
+        mockMvc.perform(patch("/api/v1/admin/users/2/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"active\":false}"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.message").value("Admins cannot modify Super Admin accounts"));
+    }
+
+    @Test @WithMockUser(roles = "ADMIN")
+    void returns400_whenActiveMissing() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin/users/10/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.errors[?(@.field=='active')]").exists());
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/UserStatusServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/UserStatusServiceTest.java
@@ -1,0 +1,111 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.cache.BlockedUserCacheService;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserStatusServiceTest {
+
+    @Mock UserRepository          userRepository;
+    @Mock BlockedUserCacheService blockedUserCache;
+
+    UserStatusService service;
+
+    private static final AuthenticatedUser ADMIN      = new AuthenticatedUser(1L, "admin@x.com", "ADMIN");
+    private static final AuthenticatedUser SUPER_ADMIN = new AuthenticatedUser(2L, "sa@x.com", "SUPER_ADMIN");
+
+    @BeforeEach
+    void setUp() {
+        service = new UserStatusService(userRepository, blockedUserCache);
+    }
+
+    private User activeCandidate(Long id) {
+        User u = User.create("c@x.com", "h", Role.CANDIDATE, "Cand");
+        u.activate();
+        return u;
+    }
+
+    private User activeSuperAdmin() {
+        User u = User.create("sa@x.com", "h", Role.SUPER_ADMIN, "SA");
+        u.activate();
+        return u;
+    }
+
+    // ── deactivate ────────────────────────────────────────────────────────────
+
+    @Test
+    void deactivate_setsInactiveAndBlocksInRedis() {
+        User user = activeCandidate(10L);
+        when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+
+        service.setStatus(10L, false, ADMIN);
+
+        assertThat(user.isActive()).isFalse();
+        verify(blockedUserCache).block(10L);
+        verify(blockedUserCache, never()).unblock(any());
+    }
+
+    // ── activate ──────────────────────────────────────────────────────────────
+
+    @Test
+    void activate_setsActiveAndUnblocksInRedis() {
+        User user = User.create("c@x.com", "h", Role.CANDIDATE, "Cand"); // inactive
+        when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+
+        service.setStatus(10L, true, ADMIN);
+
+        assertThat(user.isActive()).isTrue();
+        verify(blockedUserCache).unblock(10L);
+        verify(blockedUserCache, never()).block(any());
+    }
+
+    // ── guard: admin cannot touch SUPER_ADMIN ────────────────────────────────
+
+    @Test
+    void admin_cannotDeactivateSuperAdmin() {
+        when(userRepository.findById(99L)).thenReturn(Optional.of(activeSuperAdmin()));
+
+        assertThatThrownBy(() -> service.setStatus(99L, false, ADMIN))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Super Admin");
+
+        verifyNoInteractions(blockedUserCache);
+    }
+
+    @Test
+    void superAdmin_canDeactivateSuperAdmin() {
+        User sa = activeSuperAdmin();
+        when(userRepository.findById(99L)).thenReturn(Optional.of(sa));
+
+        service.setStatus(99L, false, SUPER_ADMIN);
+
+        assertThat(sa.isActive()).isFalse();
+        verify(blockedUserCache).block(99L);
+    }
+
+    // ── not found ─────────────────────────────────────────────────────────────
+
+    @Test
+    void throwsNotFound_whenUserMissing() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.setStatus(999L, false, ADMIN))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- `BlockedUserCacheService` — Redis-backed blocked-user list; keys `blocked_user:{id}` with JWT TTL; fails open when Redis is down
- `JwtAuthenticationFilter` — now checks blocked list after token validation; blocked users are denied without invalidating the token
- `UserStatusService` — `setStatus()` with SUPER_ADMIN guard (ADMIN cannot touch SUPER_ADMIN), activate/deactivate + Redis block/unblock
- `AdminUserController` — `PATCH /api/v1/admin/users/{id}/status` requires ADMIN+; also bundles FR-11 `POST /api/v1/admin/users/recruiter`
- FR-11 support files re-included: `RecruiterAdminService`, `WelcomeNotificationPort`, `MockWelcomeNotificationAdapter`, DTOs

## Test plan
- [ ] `BlockedUserCacheServiceTest` — 7 tests: block/unblock/isBlocked, Redis-down fail-open for all three ops
- [ ] `UserStatusServiceTest` — 6 tests: deactivate→Redis block, activate→Redis unblock, Admin blocked from SUPER_ADMIN, SUPER_ADMIN can deactivate SUPER_ADMIN, not-found throws
- [ ] `AdminUserStatusControllerTest` — 8 tests: 401 unauthenticated, 403 CANDIDATE, 403 RECRUITER, 200 deactivate, 200 activate, 404 user not found, 400 super-admin guard, 400 missing `active` field

