### PR TITLE
feat(backend): JobPosting entity and repository (FR-13)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -8,8 +8,9 @@ group = 'com.eaa'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(23)
+    }
 }
 
 configurations {

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.java.home=C:/Program Files/Java/jdk-23
+org.gradle.jvmargs=-Xmx2g

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/backend/src/main/java/com/eaa/recruit/entity/JobPosting.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/JobPosting.java
@@ -1,0 +1,67 @@
+package com.eaa.recruit.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+    name = "job_postings",
+    indexes = {
+        @Index(name = "idx_job_postings_status", columnList = "status"),
+        @Index(name = "idx_job_postings_created_by", columnList = "created_by")
+    }
+)
+public class JobPosting extends BaseEntity {
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "min_height_cm", nullable = false)
+    private Integer minHeightCm;
+
+    @Column(name = "min_weight_kg", nullable = false)
+    private Integer minWeightKg;
+
+    @Column(name = "required_degree", nullable = false, length = 100)
+    private String requiredDegree;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private JobPostingStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false, updatable = false)
+    private User createdBy;
+
+    protected JobPosting() {}
+
+    private JobPosting(String title, String description, Integer minHeightCm,
+                       Integer minWeightKg, String requiredDegree, User createdBy) {
+        this.title         = title;
+        this.description   = description;
+        this.minHeightCm   = minHeightCm;
+        this.minWeightKg   = minWeightKg;
+        this.requiredDegree = requiredDegree;
+        this.status        = JobPostingStatus.DRAFT;
+        this.createdBy     = createdBy;
+    }
+
+    public static JobPosting create(String title, String description, Integer minHeightCm,
+                                    Integer minWeightKg, String requiredDegree, User createdBy) {
+        return new JobPosting(title, description, minHeightCm, minWeightKg, requiredDegree, createdBy);
+    }
+
+    public String getTitle()           { return title; }
+    public String getDescription()     { return description; }
+    public Integer getMinHeightCm()    { return minHeightCm; }
+    public Integer getMinWeightKg()    { return minWeightKg; }
+    public String getRequiredDegree()  { return requiredDegree; }
+    public JobPostingStatus getStatus() { return status; }
+    public User getCreatedBy()         { return createdBy; }
+
+    public void publish()              { this.status = JobPostingStatus.OPEN; }
+    public void close()                { this.status = JobPostingStatus.CLOSED; }
+    public void scheduleExam()         { this.status = JobPostingStatus.EXAM_SCHEDULED; }
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/JobPostingStatus.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/JobPostingStatus.java
@@ -1,0 +1,8 @@
+package com.eaa.recruit.entity;
+
+public enum JobPostingStatus {
+    DRAFT,
+    OPEN,
+    CLOSED,
+    EXAM_SCHEDULED
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/JobPostingRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/JobPostingRepository.java
@@ -1,0 +1,14 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.JobPostingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
+
+    List<JobPosting> findByStatus(JobPostingStatus status);
+
+    List<JobPosting> findByCreatedById(Long recruiterId);
+}

--- a/backend/src/test/java/com/eaa/recruit/config/TestJpaAuditingConfig.java
+++ b/backend/src/test/java/com/eaa/recruit/config/TestJpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.eaa.recruit.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaAuditingConfig {
+}

--- a/backend/src/test/java/com/eaa/recruit/entity/JobPostingTest.java
+++ b/backend/src/test/java/com/eaa/recruit/entity/JobPostingTest.java
@@ -1,0 +1,50 @@
+package com.eaa.recruit.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JobPostingTest {
+
+    private User recruiter() {
+        return User.create("recruiter@eaa.com", "hash", Role.RECRUITER, "Alice");
+    }
+
+    private JobPosting posting() {
+        return JobPosting.create("Pilot", "Fly planes", 170, 60, "BSc Aviation", recruiter());
+    }
+
+    @Test void newPosting_statusIsDraft() {
+        assertThat(posting().getStatus()).isEqualTo(JobPostingStatus.DRAFT);
+    }
+
+    @Test void publish_setsStatusOpen() {
+        JobPosting jp = posting();
+        jp.publish();
+        assertThat(jp.getStatus()).isEqualTo(JobPostingStatus.OPEN);
+    }
+
+    @Test void close_setsStatusClosed() {
+        JobPosting jp = posting();
+        jp.publish();
+        jp.close();
+        assertThat(jp.getStatus()).isEqualTo(JobPostingStatus.CLOSED);
+    }
+
+    @Test void scheduleExam_setsStatusExamScheduled() {
+        JobPosting jp = posting();
+        jp.publish();
+        jp.scheduleExam();
+        assertThat(jp.getStatus()).isEqualTo(JobPostingStatus.EXAM_SCHEDULED);
+    }
+
+    @Test void fieldsPreserved() {
+        JobPosting jp = posting();
+        assertThat(jp.getTitle()).isEqualTo("Pilot");
+        assertThat(jp.getDescription()).isEqualTo("Fly planes");
+        assertThat(jp.getMinHeightCm()).isEqualTo(170);
+        assertThat(jp.getMinWeightKg()).isEqualTo(60);
+        assertThat(jp.getRequiredDegree()).isEqualTo("BSc Aviation");
+        assertThat(jp.getCreatedBy().getRole()).isEqualTo(Role.RECRUITER);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/repository/JobPostingRepositoryTest.java
+++ b/backend/src/test/java/com/eaa/recruit/repository/JobPostingRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.config.TestJpaAuditingConfig;
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.JobPostingStatus;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(TestJpaAuditingConfig.class)
+class JobPostingRepositoryTest {
+
+    @Autowired JobPostingRepository jobPostingRepository;
+    @Autowired UserRepository userRepository;
+
+    private User recruiter;
+
+    @BeforeEach
+    void setUp() {
+        recruiter = userRepository.save(
+            User.create("recruiter@eaa.com", "hash", Role.RECRUITER, "Alice")
+        );
+    }
+
+    @Test
+    void saveAndFindById() {
+        JobPosting saved = jobPostingRepository.save(
+            JobPosting.create("Pilot", "Fly planes", 170, 60, "BSc Aviation", recruiter)
+        );
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getStatus()).isEqualTo(JobPostingStatus.DRAFT);
+    }
+
+    @Test
+    void findByStatus_returnsMatchingPostings() {
+        JobPosting draft = jobPostingRepository.save(
+            JobPosting.create("Draft Job", "desc", 165, 55, "BSc", recruiter)
+        );
+        JobPosting open = jobPostingRepository.save(
+            JobPosting.create("Open Job", "desc", 165, 55, "BSc", recruiter)
+        );
+        open.publish();
+        jobPostingRepository.save(open);
+
+        List<JobPosting> openPostings = jobPostingRepository.findByStatus(JobPostingStatus.OPEN);
+        List<JobPosting> draftPostings = jobPostingRepository.findByStatus(JobPostingStatus.DRAFT);
+
+        assertThat(openPostings).hasSize(1);
+        assertThat(openPostings.get(0).getTitle()).isEqualTo("Open Job");
+        assertThat(draftPostings).hasSize(1);
+        assertThat(draftPostings.get(0).getTitle()).isEqualTo("Draft Job");
+    }
+
+    @Test
+    void findByCreatedById_returnsRecruiterPostings() {
+        jobPostingRepository.save(
+            JobPosting.create("Job A", "desc", 170, 60, "BSc", recruiter)
+        );
+        jobPostingRepository.save(
+            JobPosting.create("Job B", "desc", 175, 65, "MSc", recruiter)
+        );
+
+        User other = userRepository.save(
+            User.create("other@eaa.com", "hash", Role.RECRUITER, "Bob")
+        );
+        jobPostingRepository.save(
+            JobPosting.create("Job C", "desc", 160, 50, "BSc", other)
+        );
+
+        List<JobPosting> mine = jobPostingRepository.findByCreatedById(recruiter.getId());
+        assertThat(mine).hasSize(2);
+    }
+
+    @Test
+    void allStatusTransitions_persistCorrectly() {
+        JobPosting jp = jobPostingRepository.save(
+            JobPosting.create("Flight Eng", "desc", 168, 58, "BSc", recruiter)
+        );
+
+        jp.publish();
+        jobPostingRepository.save(jp);
+        assertThat(jobPostingRepository.findById(jp.getId()).orElseThrow().getStatus())
+            .isEqualTo(JobPostingStatus.OPEN);
+
+        jp.scheduleExam();
+        jobPostingRepository.save(jp);
+        assertThat(jobPostingRepository.findById(jp.getId()).orElseThrow().getStatus())
+            .isEqualTo(JobPostingStatus.EXAM_SCHEDULED);
+
+        jp.close();
+        jobPostingRepository.save(jp);
+        assertThat(jobPostingRepository.findById(jp.getId()).orElseThrow().getStatus())
+            .isEqualTo(JobPostingStatus.CLOSED);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/eaa/recruit/repository/UserRepositoryTest.java
@@ -1,10 +1,12 @@
 package com.eaa.recruit.repository;
 
+import com.eaa.recruit.config.TestJpaAuditingConfig;
 import com.eaa.recruit.entity.Role;
 import com.eaa.recruit.entity.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
@@ -14,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Import(TestJpaAuditingConfig.class)
 class UserRepositoryTest {
 
     @Autowired UserRepository userRepository;


### PR DESCRIPTION
## Summary
- Adds `JobPosting` JPA entity with title, description, hard-filter fields (`minHeightCm`, `minWeightKg`, `requiredDegree`), and `createdBy` ManyToOne relation to `User`
- Adds `JobPostingStatus` enum: `DRAFT`, `OPEN`, `CLOSED`, `EXAM_SCHEDULED`
- Factory method `JobPosting.create(...)` enforces `DRAFT` as initial status
- Adds `JobPostingRepository` with `findByStatus` and `findByCreatedById` queries
- Upgrades build toolchain to Java 23 / Gradle 8.13 to match local JDK

## Test plan
- [ ] `JobPostingTest` — entity construction, status transitions (`publish`, `close`, `scheduleExam`)
- [ ] `JobPostingRepositoryTest` — persist and query by status and recruiter ID

