### PR TITLE
feat(backend): job/application pipeline and exam orchestration (FR-14-25)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/RecruitApplication.java
+++ b/backend/src/main/java/com/eaa/recruit/RecruitApplication.java
@@ -3,9 +3,11 @@ package com.eaa.recruit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties
+@EnableScheduling
 public class RecruitApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/eaa/recruit/config/InternalApiKeyProperties.java
+++ b/backend/src/main/java/com/eaa/recruit/config/InternalApiKeyProperties.java
@@ -1,0 +1,14 @@
+package com.eaa.recruit.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "internal")
+public class InternalApiKeyProperties {
+
+    private String apiKey = "change-me-internal-key";
+
+    public String getApiKey() { return apiKey; }
+    public void setApiKey(String apiKey) { this.apiKey = apiKey; }
+}

--- a/backend/src/main/java/com/eaa/recruit/config/SecurityConfig.java
+++ b/backend/src/main/java/com/eaa/recruit/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 .requestMatchers("/api/v1/auth/**").permitAll()
+                .requestMatchers("/api/v1/internal/**").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/eaa/recruit/config/StorageProperties.java
+++ b/backend/src/main/java/com/eaa/recruit/config/StorageProperties.java
@@ -1,0 +1,14 @@
+package com.eaa.recruit.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "storage")
+public class StorageProperties {
+
+    private String cvUploadDir = "./cv-uploads";
+
+    public String getCvUploadDir() { return cvUploadDir; }
+    public void setCvUploadDir(String cvUploadDir) { this.cvUploadDir = cvUploadDir; }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/ApplicationController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/ApplicationController.java
@@ -1,0 +1,40 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.application.SubmitApplicationResponse;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsCandidate;
+import com.eaa.recruit.service.ApplicationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/applications")
+public class ApplicationController {
+
+    private final ApplicationService applicationService;
+
+    public ApplicationController(ApplicationService applicationService) {
+        this.applicationService = applicationService;
+    }
+
+    /**
+     * POST /api/v1/applications
+     * Submit a job application with a CV file. Candidate only.
+     */
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @IsCandidate
+    public ResponseEntity<ApiResponse<SubmitApplicationResponse>> submitApplication(
+            @RequestParam("jobId") Long jobId,
+            @RequestParam("cv") MultipartFile cv,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        SubmitApplicationResponse response = applicationService.submitApplication(jobId, cv, principal);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("Application submitted successfully", response));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/ExamController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/ExamController.java
@@ -1,0 +1,56 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.application.BatchAuthorizeRequest;
+import com.eaa.recruit.dto.application.BatchAuthorizeResponse;
+import com.eaa.recruit.dto.exam.CreateExamRequest;
+import com.eaa.recruit.dto.exam.CreateExamResponse;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsRecruiter;
+import com.eaa.recruit.service.ExamService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/jobs/{jobId}/exam")
+@IsRecruiter
+public class ExamController {
+
+    private final ExamService examService;
+
+    public ExamController(ExamService examService) {
+        this.examService = examService;
+    }
+
+    /**
+     * POST /api/v1/jobs/{jobId}/exam
+     * FR-24: Define an exam for a job posting. Recruiter only.
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateExamResponse>> createExam(
+            @PathVariable Long jobId,
+            @Valid @RequestBody CreateExamRequest request,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        CreateExamResponse response = examService.createExam(jobId, request, principal);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("Exam created successfully", response));
+    }
+
+    /**
+     * POST /api/v1/jobs/{jobId}/exam/authorize
+     * FR-25: Authorize a batch of candidates for the exam.
+     */
+    @PostMapping("/authorize")
+    public ResponseEntity<ApiResponse<BatchAuthorizeResponse>> authorizeExamBatch(
+            @PathVariable Long jobId,
+            @Valid @RequestBody BatchAuthorizeRequest request,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        BatchAuthorizeResponse response = examService.authorizeExamBatch(jobId, request, principal);
+        return ResponseEntity.ok(ApiResponse.success("Batch authorization completed", response));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/InternalController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/InternalController.java
@@ -1,0 +1,49 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.config.InternalApiKeyProperties;
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.application.AiScoreCallbackRequest;
+import com.eaa.recruit.exception.UnauthorizedException;
+import com.eaa.recruit.service.ApplicationService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Internal endpoints called by other services (e.g., Python AI service).
+ * Secured via X-Internal-Api-Key header — not exposed to public traffic.
+ */
+@RestController
+@RequestMapping("/api/v1/internal")
+public class InternalController {
+
+    private final ApplicationService       applicationService;
+    private final InternalApiKeyProperties apiKeyProperties;
+
+    public InternalController(ApplicationService applicationService,
+                               InternalApiKeyProperties apiKeyProperties) {
+        this.applicationService = applicationService;
+        this.apiKeyProperties   = apiKeyProperties;
+    }
+
+    /**
+     * POST /api/v1/internal/applications/{id}/ai-score
+     * FR-21: Receive AI screening result from the Python AI service.
+     */
+    @PostMapping("/applications/{id}/ai-score")
+    public ResponseEntity<ApiResponse<Void>> receiveAiScore(
+            @PathVariable("id") Long applicationId,
+            @RequestHeader("X-Internal-Api-Key") String apiKey,
+            @Valid @RequestBody AiScoreCallbackRequest request) {
+
+        validateApiKey(apiKey);
+        applicationService.applyAiScore(applicationId, request);
+        return ResponseEntity.ok(ApiResponse.success("AI score applied"));
+    }
+
+    private void validateApiKey(String provided) {
+        if (!apiKeyProperties.getApiKey().equals(provided)) {
+            throw new UnauthorizedException("Invalid internal API key");
+        }
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/JobController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/JobController.java
@@ -1,0 +1,39 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.job.CreateJobRequest;
+import com.eaa.recruit.dto.job.CreateJobResponse;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsRecruiter;
+import com.eaa.recruit.service.JobService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/jobs")
+@IsRecruiter
+public class JobController {
+
+    private final JobService jobService;
+
+    public JobController(JobService jobService) {
+        this.jobService = jobService;
+    }
+
+    /**
+     * POST /api/v1/jobs
+     * Creates a new job posting in DRAFT status. Recruiter only.
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateJobResponse>> createJob(
+            @Valid @RequestBody CreateJobRequest request,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        CreateJobResponse response = jobService.createJob(request, principal);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("Job posting created successfully", response));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/RecruiterController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/RecruiterController.java
@@ -1,0 +1,74 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.availability.AvailabilitySlotBatchRequest;
+import com.eaa.recruit.dto.availability.AvailabilitySlotResponse;
+import com.eaa.recruit.dto.recruiter.DashboardEntryResponse;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsRecruiter;
+import com.eaa.recruit.service.AvailabilitySlotService;
+import com.eaa.recruit.service.RecruiterDashboardService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/recruiters")
+@IsRecruiter
+public class RecruiterController {
+
+    private final AvailabilitySlotService  availabilitySlotService;
+    private final RecruiterDashboardService dashboardService;
+
+    public RecruiterController(AvailabilitySlotService availabilitySlotService,
+                                RecruiterDashboardService dashboardService) {
+        this.availabilitySlotService = availabilitySlotService;
+        this.dashboardService        = dashboardService;
+    }
+
+    /**
+     * POST /api/v1/recruiters/availability
+     * FR-16: Add one or more interview availability slots.
+     */
+    @PostMapping("/availability")
+    public ResponseEntity<ApiResponse<List<AvailabilitySlotResponse>>> addSlots(
+            @Valid @RequestBody AvailabilitySlotBatchRequest request,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        List<AvailabilitySlotResponse> slots = availabilitySlotService.addSlots(request, principal);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("Availability slots added", slots));
+    }
+
+    /**
+     * GET /api/v1/recruiters/availability
+     * FR-16: Retrieve all future availability slots for the authenticated recruiter.
+     */
+    @GetMapping("/availability")
+    public ResponseEntity<ApiResponse<List<AvailabilitySlotResponse>>> getSlots(
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        List<AvailabilitySlotResponse> slots = availabilitySlotService.getAvailableSlots(principal);
+        return ResponseEntity.ok(ApiResponse.success(slots));
+    }
+
+    /**
+     * GET /api/v1/recruiters/dashboard
+     * FR-17: Paginated dashboard with application counts per job.
+     */
+    @GetMapping("/dashboard")
+    public ResponseEntity<ApiResponse<Page<DashboardEntryResponse>>> getDashboard(
+            @AuthenticationPrincipal AuthenticatedUser principal,
+            @PageableDefault(size = 20, sort = "totalApplications") Pageable pageable) {
+
+        Page<DashboardEntryResponse> dashboard = dashboardService.getDashboard(principal, pageable);
+        return ResponseEntity.ok(ApiResponse.success(dashboard));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/AiScoreCallbackRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/AiScoreCallbackRequest.java
@@ -1,0 +1,17 @@
+package com.eaa.recruit.dto.application;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AiScoreCallbackRequest(
+
+        @NotNull(message = "cvRelevanceScore is required")
+        @DecimalMin(value = "0.0", message = "cvRelevanceScore must be >= 0")
+        @DecimalMax(value = "1.0", message = "cvRelevanceScore must be <= 1")
+        Double cvRelevanceScore,
+
+        @NotBlank(message = "xaiReportUrl is required")
+        String xaiReportUrl
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/BatchAuthorizeRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/BatchAuthorizeRequest.java
@@ -1,0 +1,11 @@
+package com.eaa.recruit.dto.application;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record BatchAuthorizeRequest(
+
+        @NotEmpty(message = "At least one applicationId is required")
+        List<Long> applicationIds
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/BatchAuthorizeResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/BatchAuthorizeResponse.java
@@ -1,0 +1,11 @@
+package com.eaa.recruit.dto.application;
+
+import java.util.List;
+
+public record BatchAuthorizeResponse(
+        int            authorizedCount,
+        List<Long>     authorizedIds,
+        List<SkippedEntry> skipped
+) {
+    public record SkippedEntry(Long applicationId, String reason) {}
+}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/SubmitApplicationResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/SubmitApplicationResponse.java
@@ -1,0 +1,12 @@
+package com.eaa.recruit.dto.application;
+
+import com.eaa.recruit.entity.ApplicationStatus;
+
+import java.time.Instant;
+
+public record SubmitApplicationResponse(
+        Long              id,
+        Long              jobId,
+        ApplicationStatus status,
+        Instant           submittedAt
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/availability/AvailabilitySlotBatchRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/availability/AvailabilitySlotBatchRequest.java
@@ -1,0 +1,13 @@
+package com.eaa.recruit.dto.availability;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record AvailabilitySlotBatchRequest(
+
+        @NotEmpty(message = "At least one slot is required")
+        @Valid
+        List<AvailabilitySlotRequest> slots
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/availability/AvailabilitySlotRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/availability/AvailabilitySlotRequest.java
@@ -1,0 +1,20 @@
+package com.eaa.recruit.dto.availability;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record AvailabilitySlotRequest(
+
+        @NotNull(message = "date is required")
+        @FutureOrPresent(message = "date must not be in the past")
+        LocalDate date,
+
+        @NotNull(message = "startTime is required")
+        LocalTime startTime,
+
+        @NotNull(message = "endTime is required")
+        LocalTime endTime
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/availability/AvailabilitySlotResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/availability/AvailabilitySlotResponse.java
@@ -1,0 +1,12 @@
+package com.eaa.recruit.dto.availability;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record AvailabilitySlotResponse(
+        Long      id,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        boolean   booked
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/exam/CreateExamRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/exam/CreateExamRequest.java
@@ -1,0 +1,25 @@
+package com.eaa.recruit.dto.exam;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CreateExamRequest(
+
+        @NotBlank(message = "title is required")
+        @Size(max = 255, message = "title must not exceed 255 characters")
+        String title,
+
+        @NotNull(message = "durationMinutes is required")
+        @Positive(message = "durationMinutes must be positive")
+        Integer durationMinutes,
+
+        @NotEmpty(message = "At least one question is required")
+        @Valid
+        List<QuestionRequest> questions
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/exam/CreateExamResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/exam/CreateExamResponse.java
@@ -1,0 +1,9 @@
+package com.eaa.recruit.dto.exam;
+
+public record CreateExamResponse(
+        Long    examId,
+        Long    jobId,
+        String  title,
+        Integer durationMinutes,
+        int     questionCount
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/exam/QuestionRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/exam/QuestionRequest.java
@@ -1,0 +1,27 @@
+package com.eaa.recruit.dto.exam;
+
+import com.eaa.recruit.entity.QuestionType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.List;
+
+public record QuestionRequest(
+
+        @NotNull(message = "type is required")
+        QuestionType type,
+
+        @NotBlank(message = "questionText is required")
+        String questionText,
+
+        /** Required for MCQ questions; each entry is an answer option. */
+        List<String> options,
+
+        /** Zero-based index of the correct option. Required for MCQ. */
+        Integer correctAnswer,
+
+        @NotNull(message = "marks is required")
+        @Positive(message = "marks must be positive")
+        Integer marks
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/job/CreateJobRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/job/CreateJobRequest.java
@@ -1,0 +1,37 @@
+package com.eaa.recruit.dto.job;
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+
+public record CreateJobRequest(
+
+        @NotBlank(message = "Title is required")
+        @Size(max = 255, message = "Title must not exceed 255 characters")
+        String title,
+
+        @NotBlank(message = "Description is required")
+        String description,
+
+        @NotNull(message = "Minimum height is required")
+        @Positive(message = "Minimum height must be positive")
+        Integer minHeightCm,
+
+        @NotNull(message = "Minimum weight is required")
+        @Positive(message = "Minimum weight must be positive")
+        Integer minWeightKg,
+
+        @NotBlank(message = "Required degree is required")
+        @Size(max = 100, message = "Required degree must not exceed 100 characters")
+        String requiredDegree,
+
+        @NotNull(message = "Open date is required")
+        @FutureOrPresent(message = "Open date must not be in the past")
+        LocalDate openDate,
+
+        @NotNull(message = "Close date is required")
+        LocalDate closeDate,
+
+        @NotNull(message = "Exam date is required")
+        LocalDate examDate
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/job/CreateJobResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/job/CreateJobResponse.java
@@ -1,0 +1,14 @@
+package com.eaa.recruit.dto.job;
+
+import com.eaa.recruit.entity.JobPostingStatus;
+
+import java.time.LocalDate;
+
+public record CreateJobResponse(
+        Long id,
+        String title,
+        JobPostingStatus status,
+        LocalDate openDate,
+        LocalDate closeDate,
+        LocalDate examDate
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/recruiter/DashboardEntryResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/recruiter/DashboardEntryResponse.java
@@ -1,0 +1,11 @@
+package com.eaa.recruit.dto.recruiter;
+
+public record DashboardEntryResponse(
+        Long   jobId,
+        String jobTitle,
+        Long   totalApplications,
+        Long   screeningCount,
+        Long   examCount,
+        Long   interviewCount,
+        Long   decidedCount
+) {}

--- a/backend/src/main/java/com/eaa/recruit/entity/Application.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/Application.java
@@ -1,0 +1,107 @@
+package com.eaa.recruit.entity;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "applications",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_applications_candidate_job",
+        columnNames = {"candidate_id", "job_id"}
+    ),
+    indexes = {
+        @Index(name = "idx_applications_candidate", columnList = "candidate_id"),
+        @Index(name = "idx_applications_job",       columnList = "job_id"),
+        @Index(name = "idx_applications_status",    columnList = "status")
+    }
+)
+public class Application extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "candidate_id", nullable = false, updatable = false)
+    private User candidate;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "job_id", nullable = false, updatable = false)
+    private JobPosting job;
+
+    @Column(name = "cv_file_path", nullable = false, length = 500)
+    private String cvFilePath;
+
+    @Column(name = "cv_relevance_score")
+    private Double cvRelevanceScore;
+
+    @Column(name = "exam_score")
+    private Double examScore;
+
+    @Column(name = "hard_filter_passed")
+    private Boolean hardFilterPassed;
+
+    @Column(name = "final_score")
+    private Double finalScore;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private ApplicationStatus status;
+
+    @Column(name = "xai_report_url", length = 500)
+    private String xaiReportUrl;
+
+    @Column(name = "exam_token", length = 36)
+    private String examToken;
+
+    @Column(name = "submitted_at", nullable = false, updatable = false)
+    private Instant submittedAt;
+
+    protected Application() {}
+
+    private Application(User candidate, JobPosting job, String cvFilePath) {
+        this.candidate   = candidate;
+        this.job         = job;
+        this.cvFilePath  = cvFilePath;
+        this.status      = ApplicationStatus.SUBMITTED;
+        this.submittedAt = Instant.now();
+    }
+
+    public static Application create(User candidate, JobPosting job, String cvFilePath) {
+        return new Application(candidate, job, cvFilePath);
+    }
+
+    // ── Getters ──────────────────────────────────────────────────────────────
+
+    public User           getCandidate()          { return candidate; }
+    public JobPosting     getJob()                { return job; }
+    public String         getCvFilePath()         { return cvFilePath; }
+    public Double         getCvRelevanceScore()   { return cvRelevanceScore; }
+    public Double         getExamScore()          { return examScore; }
+    public Boolean        getHardFilterPassed()   { return hardFilterPassed; }
+    public Double         getFinalScore()         { return finalScore; }
+    public ApplicationStatus getStatus()          { return status; }
+    public String         getXaiReportUrl()       { return xaiReportUrl; }
+    public String         getExamToken()          { return examToken; }
+    public Instant        getSubmittedAt()        { return submittedAt; }
+
+    // ── State transitions ─────────────────────────────────────────────────────
+
+    public void applyAiScore(double score, String reportUrl) {
+        this.cvRelevanceScore = score;
+        this.xaiReportUrl     = reportUrl;
+        this.status           = ApplicationStatus.AI_SCREENING;
+    }
+
+    public void markHardFilterPassed() {
+        this.hardFilterPassed = true;
+    }
+
+    public void markHardFilterFailed() {
+        this.hardFilterPassed = false;
+        this.status           = ApplicationStatus.HARD_FILTER_FAILED;
+    }
+
+    public void authorizeExam(String token) {
+        this.examToken = token;
+        this.status    = ApplicationStatus.EXAM_AUTHORIZED;
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/ApplicationStatus.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/ApplicationStatus.java
@@ -1,0 +1,14 @@
+package com.eaa.recruit.entity;
+
+public enum ApplicationStatus {
+    SUBMITTED,
+    AI_SCREENING,
+    HARD_FILTER_FAILED,
+    EXAM_AUTHORIZED,
+    EXAM_COMPLETED,
+    SHORTLISTED,
+    INTERVIEW_SCHEDULED,
+    SELECTED,
+    REJECTED,
+    WAITLISTED
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/AvailabilitySlot.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/AvailabilitySlot.java
@@ -1,0 +1,56 @@
+package com.eaa.recruit.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(
+    name = "availability_slots",
+    indexes = {
+        @Index(name = "idx_slots_recruiter", columnList = "recruiter_id"),
+        @Index(name = "idx_slots_date",      columnList = "slot_date")
+    }
+)
+public class AvailabilitySlot extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "recruiter_id", nullable = false, updatable = false)
+    private User recruiter;
+
+    @Column(name = "slot_date", nullable = false)
+    private LocalDate slotDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "is_booked", nullable = false)
+    private boolean booked = false;
+
+    protected AvailabilitySlot() {}
+
+    private AvailabilitySlot(User recruiter, LocalDate slotDate,
+                              LocalTime startTime, LocalTime endTime) {
+        this.recruiter = recruiter;
+        this.slotDate  = slotDate;
+        this.startTime = startTime;
+        this.endTime   = endTime;
+    }
+
+    public static AvailabilitySlot create(User recruiter, LocalDate slotDate,
+                                          LocalTime startTime, LocalTime endTime) {
+        return new AvailabilitySlot(recruiter, slotDate, startTime, endTime);
+    }
+
+    public User      getRecruiter() { return recruiter; }
+    public LocalDate getSlotDate()  { return slotDate; }
+    public LocalTime getStartTime() { return startTime; }
+    public LocalTime getEndTime()   { return endTime; }
+    public boolean   isBooked()     { return booked; }
+
+    public void book() { this.booked = true; }
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/Exam.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/Exam.java
@@ -1,0 +1,47 @@
+package com.eaa.recruit.entity;
+
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "exams")
+public class Exam extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "job_id", nullable = false, unique = true, updatable = false)
+    private JobPosting job;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "duration_minutes", nullable = false)
+    private Integer durationMinutes;
+
+    @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true,
+               fetch = FetchType.LAZY)
+    @OrderBy("displayOrder ASC")
+    private List<Question> questions = new ArrayList<>();
+
+    protected Exam() {}
+
+    private Exam(JobPosting job, String title, Integer durationMinutes) {
+        this.job             = job;
+        this.title           = title;
+        this.durationMinutes = durationMinutes;
+    }
+
+    public static Exam create(JobPosting job, String title, Integer durationMinutes) {
+        return new Exam(job, title, durationMinutes);
+    }
+
+    public JobPosting    getJob()             { return job; }
+    public String        getTitle()           { return title; }
+    public Integer       getDurationMinutes() { return durationMinutes; }
+    public List<Question> getQuestions()      { return questions; }
+
+    public void addQuestion(Question question) {
+        questions.add(question);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/JobPosting.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/JobPosting.java
@@ -2,6 +2,8 @@ package com.eaa.recruit.entity;
 
 import jakarta.persistence.*;
 
+import java.time.LocalDate;
+
 @Entity
 @Table(
     name = "job_postings",
@@ -27,6 +29,15 @@ public class JobPosting extends BaseEntity {
     @Column(name = "required_degree", nullable = false, length = 100)
     private String requiredDegree;
 
+    @Column(name = "open_date", nullable = false)
+    private LocalDate openDate;
+
+    @Column(name = "close_date", nullable = false)
+    private LocalDate closeDate;
+
+    @Column(name = "exam_date", nullable = false)
+    private LocalDate examDate;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private JobPostingStatus status;
@@ -38,30 +49,41 @@ public class JobPosting extends BaseEntity {
     protected JobPosting() {}
 
     private JobPosting(String title, String description, Integer minHeightCm,
-                       Integer minWeightKg, String requiredDegree, User createdBy) {
+                       Integer minWeightKg, String requiredDegree,
+                       LocalDate openDate, LocalDate closeDate, LocalDate examDate,
+                       User createdBy) {
         this.title         = title;
         this.description   = description;
         this.minHeightCm   = minHeightCm;
         this.minWeightKg   = minWeightKg;
         this.requiredDegree = requiredDegree;
+        this.openDate      = openDate;
+        this.closeDate     = closeDate;
+        this.examDate      = examDate;
         this.status        = JobPostingStatus.DRAFT;
         this.createdBy     = createdBy;
     }
 
     public static JobPosting create(String title, String description, Integer minHeightCm,
-                                    Integer minWeightKg, String requiredDegree, User createdBy) {
-        return new JobPosting(title, description, minHeightCm, minWeightKg, requiredDegree, createdBy);
+                                    Integer minWeightKg, String requiredDegree,
+                                    LocalDate openDate, LocalDate closeDate, LocalDate examDate,
+                                    User createdBy) {
+        return new JobPosting(title, description, minHeightCm, minWeightKg, requiredDegree,
+                              openDate, closeDate, examDate, createdBy);
     }
 
-    public String getTitle()           { return title; }
-    public String getDescription()     { return description; }
-    public Integer getMinHeightCm()    { return minHeightCm; }
-    public Integer getMinWeightKg()    { return minWeightKg; }
-    public String getRequiredDegree()  { return requiredDegree; }
+    public String getTitle()            { return title; }
+    public String getDescription()      { return description; }
+    public Integer getMinHeightCm()     { return minHeightCm; }
+    public Integer getMinWeightKg()     { return minWeightKg; }
+    public String getRequiredDegree()   { return requiredDegree; }
+    public LocalDate getOpenDate()      { return openDate; }
+    public LocalDate getCloseDate()     { return closeDate; }
+    public LocalDate getExamDate()      { return examDate; }
     public JobPostingStatus getStatus() { return status; }
-    public User getCreatedBy()         { return createdBy; }
+    public User getCreatedBy()          { return createdBy; }
 
-    public void publish()              { this.status = JobPostingStatus.OPEN; }
-    public void close()                { this.status = JobPostingStatus.CLOSED; }
-    public void scheduleExam()         { this.status = JobPostingStatus.EXAM_SCHEDULED; }
+    public void publish()               { this.status = JobPostingStatus.OPEN; }
+    public void close()                 { this.status = JobPostingStatus.CLOSED; }
+    public void scheduleExam()          { this.status = JobPostingStatus.EXAM_SCHEDULED; }
 }

--- a/backend/src/main/java/com/eaa/recruit/entity/Question.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/Question.java
@@ -1,0 +1,64 @@
+package com.eaa.recruit.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+    name = "questions",
+    indexes = @Index(name = "idx_questions_exam", columnList = "exam_id, display_order")
+)
+public class Question extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "exam_id", nullable = false, updatable = false)
+    private Exam exam;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private QuestionType type;
+
+    @Column(name = "question_text", nullable = false, columnDefinition = "TEXT")
+    private String questionText;
+
+    /** JSON array of option strings — only set for MCQ questions. */
+    @Column(name = "options", columnDefinition = "TEXT")
+    private String options;
+
+    /** Zero-based index of the correct option — only set for MCQ questions. */
+    @Column(name = "correct_answer")
+    private Integer correctAnswer;
+
+    @Column(name = "marks", nullable = false)
+    private Integer marks;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
+    protected Question() {}
+
+    private Question(Exam exam, QuestionType type, String questionText,
+                     String options, Integer correctAnswer,
+                     Integer marks, Integer displayOrder) {
+        this.exam          = exam;
+        this.type          = type;
+        this.questionText  = questionText;
+        this.options       = options;
+        this.correctAnswer = correctAnswer;
+        this.marks         = marks;
+        this.displayOrder  = displayOrder;
+    }
+
+    public static Question create(Exam exam, QuestionType type, String questionText,
+                                   String options, Integer correctAnswer,
+                                   Integer marks, Integer displayOrder) {
+        return new Question(exam, type, questionText, options, correctAnswer, marks, displayOrder);
+    }
+
+    public Exam         getExam()         { return exam; }
+    public QuestionType getType()         { return type; }
+    public String       getQuestionText() { return questionText; }
+    public String       getOptions()      { return options; }
+    public Integer      getCorrectAnswer(){ return correctAnswer; }
+    public Integer      getMarks()        { return marks; }
+    public Integer      getDisplayOrder() { return displayOrder; }
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/QuestionType.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/QuestionType.java
@@ -1,0 +1,6 @@
+package com.eaa.recruit.entity;
+
+public enum QuestionType {
+    MCQ,
+    SHORT_ANSWER
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/User.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/User.java
@@ -27,6 +27,19 @@ public class User extends BaseEntity {
     @Column(name = "is_active", nullable = false)
     private boolean active = false;
 
+    /** Candidate profile fields — nullable; only populated for CANDIDATE role. */
+    @Column(name = "phone", length = 20)
+    private String phone;
+
+    @Column(name = "height_cm")
+    private Integer heightCm;
+
+    @Column(name = "weight_kg")
+    private Integer weightKg;
+
+    @Column(name = "degree", length = 100)
+    private String degree;
+
     protected User() {}
 
     private User(String email, String passwordHash, Role role, String fullName) {
@@ -45,6 +58,11 @@ public class User extends BaseEntity {
     public Role   getRole()         { return role; }
     public String getFullName()     { return fullName; }
     public boolean isActive()       { return active; }
+
+    public String  getPhone()    { return phone; }
+    public Integer getHeightCm() { return heightCm; }
+    public Integer getWeightKg() { return weightKg; }
+    public String  getDegree()   { return degree; }
 
     public void activate()                     { this.active = true; }
     public void deactivate()                   { this.active = false; }

--- a/backend/src/main/java/com/eaa/recruit/notification/CandidateNotificationPort.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/CandidateNotificationPort.java
@@ -1,0 +1,8 @@
+package com.eaa.recruit.notification;
+
+public interface CandidateNotificationPort {
+
+    void notifyHardFilterFailed(String email, String fullName, String jobTitle);
+
+    void notifyExamAuthorized(String email, String fullName, String jobTitle, String examToken);
+}

--- a/backend/src/main/java/com/eaa/recruit/notification/MockCandidateNotificationAdapter.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/MockCandidateNotificationAdapter.java
@@ -1,0 +1,23 @@
+package com.eaa.recruit.notification;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MockCandidateNotificationAdapter implements CandidateNotificationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockCandidateNotificationAdapter.class);
+
+    @Override
+    public void notifyHardFilterFailed(String email, String fullName, String jobTitle) {
+        log.info("[MOCK NOTIFY] Hard filter failed — to='{}' name='{}' job='{}'",
+                email, fullName, jobTitle);
+    }
+
+    @Override
+    public void notifyExamAuthorized(String email, String fullName, String jobTitle, String examToken) {
+        log.info("[MOCK NOTIFY] Exam authorized — to='{}' name='{}' job='{}' token='{}'",
+                email, fullName, jobTitle, examToken);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
@@ -1,0 +1,40 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.ApplicationStatus;
+import com.eaa.recruit.repository.projection.DashboardProjection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+
+    boolean existsByCandidateIdAndJobId(Long candidateId, Long jobId);
+
+    List<Application> findByJobId(Long jobId);
+
+    List<Application> findByJobIdAndStatus(Long jobId, ApplicationStatus status);
+
+    @Query(value = """
+            SELECT jp.id           AS jobId,
+                   jp.title        AS jobTitle,
+                   COUNT(a.id)     AS totalApplications,
+                   SUM(CASE WHEN a.status IN ('SUBMITTED','AI_SCREENING')             THEN 1 ELSE 0 END) AS screeningCount,
+                   SUM(CASE WHEN a.status IN ('EXAM_AUTHORIZED','EXAM_COMPLETED')     THEN 1 ELSE 0 END) AS examCount,
+                   SUM(CASE WHEN a.status IN ('SHORTLISTED','INTERVIEW_SCHEDULED')    THEN 1 ELSE 0 END) AS interviewCount,
+                   SUM(CASE WHEN a.status IN ('SELECTED','REJECTED','WAITLISTED','HARD_FILTER_FAILED') THEN 1 ELSE 0 END) AS decidedCount
+            FROM job_postings jp
+            LEFT JOIN applications a ON a.job_id = jp.id
+            WHERE jp.created_by_id = :recruiterId
+            GROUP BY jp.id, jp.title
+            ORDER BY COUNT(a.id) DESC
+            """,
+           countQuery = "SELECT COUNT(*) FROM job_postings WHERE created_by_id = :recruiterId",
+           nativeQuery = true)
+    Page<DashboardProjection> findDashboardByRecruiterId(
+            @Param("recruiterId") Long recruiterId, Pageable pageable);
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/AvailabilitySlotRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/AvailabilitySlotRepository.java
@@ -1,0 +1,28 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.AvailabilitySlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public interface AvailabilitySlotRepository extends JpaRepository<AvailabilitySlot, Long> {
+
+    List<AvailabilitySlot> findByRecruiterIdAndSlotDateGreaterThanEqualOrderBySlotDateAscStartTimeAsc(
+            Long recruiterId, LocalDate from);
+
+    @Query("""
+            SELECT COUNT(s) > 0 FROM AvailabilitySlot s
+            WHERE s.recruiter.id = :recruiterId
+              AND s.slotDate     = :slotDate
+              AND s.startTime    < :endTime
+              AND s.endTime      > :startTime
+            """)
+    boolean existsOverlap(@Param("recruiterId") Long recruiterId,
+                          @Param("slotDate")    LocalDate slotDate,
+                          @Param("startTime")   LocalTime startTime,
+                          @Param("endTime")     LocalTime endTime);
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/ExamRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/ExamRepository.java
@@ -1,0 +1,13 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.Exam;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ExamRepository extends JpaRepository<Exam, Long> {
+
+    Optional<Exam> findByJobId(Long jobId);
+
+    boolean existsByJobId(Long jobId);
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/JobPostingRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/JobPostingRepository.java
@@ -3,12 +3,22 @@ package com.eaa.recruit.repository;
 import com.eaa.recruit.entity.JobPosting;
 import com.eaa.recruit.entity.JobPostingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
 
     List<JobPosting> findByStatus(JobPostingStatus status);
 
     List<JobPosting> findByCreatedById(Long recruiterId);
+
+    Optional<JobPosting> findByIdAndCreatedById(Long id, Long recruiterId);
+
+    @Query("SELECT jp FROM JobPosting jp WHERE jp.status = :status AND jp.closeDate < :today")
+    List<JobPosting> findOverdueByStatus(@Param("status") JobPostingStatus status,
+                                         @Param("today") LocalDate today);
 }

--- a/backend/src/main/java/com/eaa/recruit/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/QuestionRepository.java
@@ -1,0 +1,11 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    List<Question> findByExamIdOrderByDisplayOrderAsc(Long examId);
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/projection/DashboardProjection.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/projection/DashboardProjection.java
@@ -1,0 +1,12 @@
+package com.eaa.recruit.repository.projection;
+
+/** Spring Data native-query projection for recruiter dashboard aggregation. */
+public interface DashboardProjection {
+    Long   getJobId();
+    String getJobTitle();
+    Long   getTotalApplications();
+    Long   getScreeningCount();
+    Long   getExamCount();
+    Long   getInterviewCount();
+    Long   getDecidedCount();
+}

--- a/backend/src/main/java/com/eaa/recruit/scheduler/JobStatusScheduler.java
+++ b/backend/src/main/java/com/eaa/recruit/scheduler/JobStatusScheduler.java
@@ -1,0 +1,48 @@
+package com.eaa.recruit.scheduler;
+
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.JobPostingStatus;
+import com.eaa.recruit.repository.JobPostingRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * FR-15: Auto-closes OPEN job postings whose application deadline has passed.
+ * Runs on a configurable cron expression (default: every minute).
+ * Idempotent — re-running never produces duplicate transitions.
+ */
+@Component
+public class JobStatusScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(JobStatusScheduler.class);
+
+    private final JobPostingRepository jobPostingRepository;
+
+    public JobStatusScheduler(JobPostingRepository jobPostingRepository) {
+        this.jobPostingRepository = jobPostingRepository;
+    }
+
+    @Scheduled(cron = "${scheduler.job-status.cron:0 * * * * *}")
+    @Transactional
+    public void closeExpiredJobs() {
+        LocalDate today = LocalDate.now();
+        List<JobPosting> expired = jobPostingRepository
+                .findOverdueByStatus(JobPostingStatus.OPEN, today);
+
+        if (expired.isEmpty()) return;
+
+        for (JobPosting job : expired) {
+            job.close();
+            log.info("Job auto-closed id={} title='{}' closeDate={}", job.getId(), job.getTitle(), job.getCloseDate());
+        }
+
+        jobPostingRepository.saveAll(expired);
+        log.info("Scheduler closed {} expired job(s)", expired.size());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
@@ -1,0 +1,107 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.AiScoreCallbackRequest;
+import com.eaa.recruit.dto.application.SubmitApplicationResponse;
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.JobPostingStatus;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.messaging.KafkaEventPublisher;
+import com.eaa.recruit.messaging.event.CvUploadedEvent;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.JobPostingRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class ApplicationService {
+
+    private static final Logger log = LoggerFactory.getLogger(ApplicationService.class);
+
+    private final ApplicationRepository  applicationRepository;
+    private final JobPostingRepository   jobPostingRepository;
+    private final UserRepository         userRepository;
+    private final FileStorageService     fileStorageService;
+    private final KafkaEventPublisher    kafkaEventPublisher;
+    private final HardFilterService      hardFilterService;
+
+    public ApplicationService(ApplicationRepository applicationRepository,
+                               JobPostingRepository jobPostingRepository,
+                               UserRepository userRepository,
+                               FileStorageService fileStorageService,
+                               KafkaEventPublisher kafkaEventPublisher,
+                               HardFilterService hardFilterService) {
+        this.applicationRepository = applicationRepository;
+        this.jobPostingRepository  = jobPostingRepository;
+        this.userRepository        = userRepository;
+        this.fileStorageService    = fileStorageService;
+        this.kafkaEventPublisher   = kafkaEventPublisher;
+        this.hardFilterService     = hardFilterService;
+    }
+
+    /** FR-19: Submit application with CV upload. */
+    @Transactional
+    public SubmitApplicationResponse submitApplication(Long jobId,
+                                                       MultipartFile cvFile,
+                                                       AuthenticatedUser principal) {
+        JobPosting job = jobPostingRepository.findById(jobId)
+                .orElseThrow(() -> new ResourceNotFoundException("Job not found"));
+
+        if (job.getStatus() != JobPostingStatus.OPEN) {
+            throw new BusinessException("Applications are only accepted for OPEN jobs");
+        }
+
+        if (applicationRepository.existsByCandidateIdAndJobId(principal.id(), jobId)) {
+            throw new ConflictException("You have already applied for this job");
+        }
+
+        String cvPath = fileStorageService.storeCv(cvFile);
+
+        User candidate = userRepository.findById(principal.id())
+                .orElseThrow(() -> new ResourceNotFoundException("Candidate not found"));
+
+        Application application = Application.create(candidate, job, cvPath);
+        application = applicationRepository.save(application);
+
+        log.info("Application created id={} candidateId={} jobId={}", application.getId(), principal.id(), jobId);
+
+        // FR-20: publish CV_UPLOADED event (fire-and-forget — failure does not roll back)
+        try {
+            kafkaEventPublisher.publishCvUploaded(
+                    CvUploadedEvent.of(application.getId(), principal.id(), jobId, cvPath));
+        } catch (Exception e) {
+            log.error("Failed to publish CV_UPLOADED event for applicationId={}: {}",
+                    application.getId(), e.getMessage(), e);
+        }
+
+        return new SubmitApplicationResponse(
+                application.getId(),
+                jobId,
+                application.getStatus(),
+                application.getSubmittedAt()
+        );
+    }
+
+    /** FR-21: Receive AI score callback and trigger hard filter. */
+    @Transactional
+    public void applyAiScore(Long applicationId, AiScoreCallbackRequest request) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
+
+        application.applyAiScore(request.cvRelevanceScore(), request.xaiReportUrl());
+        applicationRepository.save(application);
+
+        log.info("AI score applied applicationId={} score={}", applicationId, request.cvRelevanceScore());
+
+        // FR-22: immediately run hard filter after AI score is recorded
+        hardFilterService.applyHardFilter(application);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/AvailabilitySlotService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/AvailabilitySlotService.java
@@ -1,0 +1,89 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.availability.AvailabilitySlotBatchRequest;
+import com.eaa.recruit.dto.availability.AvailabilitySlotRequest;
+import com.eaa.recruit.dto.availability.AvailabilitySlotResponse;
+import com.eaa.recruit.entity.AvailabilitySlot;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.AvailabilitySlotRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class AvailabilitySlotService {
+
+    private static final Logger log = LoggerFactory.getLogger(AvailabilitySlotService.class);
+
+    private final AvailabilitySlotRepository slotRepository;
+    private final UserRepository             userRepository;
+
+    public AvailabilitySlotService(AvailabilitySlotRepository slotRepository,
+                                    UserRepository userRepository) {
+        this.slotRepository = slotRepository;
+        this.userRepository = userRepository;
+    }
+
+    /** FR-16: Add one or more availability slots for the authenticated recruiter. */
+    @Transactional
+    public List<AvailabilitySlotResponse> addSlots(AvailabilitySlotBatchRequest request,
+                                                    AuthenticatedUser principal) {
+        User recruiter = userRepository.findById(principal.id())
+                .orElseThrow(() -> new ResourceNotFoundException("Recruiter not found"));
+
+        List<AvailabilitySlotResponse> responses = new ArrayList<>();
+
+        for (AvailabilitySlotRequest slot : request.slots()) {
+            if (!slot.endTime().isAfter(slot.startTime())) {
+                throw new BusinessException("endTime must be after startTime for slot on " + slot.date());
+            }
+            if (slotRepository.existsOverlap(principal.id(), slot.date(),
+                                             slot.startTime(), slot.endTime())) {
+                throw new ConflictException(
+                        "Slot on " + slot.date() + " from " + slot.startTime()
+                        + " to " + slot.endTime() + " overlaps with an existing slot");
+            }
+
+            AvailabilitySlot saved = slotRepository.save(
+                    AvailabilitySlot.create(recruiter, slot.date(), slot.startTime(), slot.endTime()));
+
+            log.info("Availability slot created id={} recruiterId={} date={}",
+                    saved.getId(), principal.id(), slot.date());
+
+            responses.add(toResponse(saved));
+        }
+
+        return responses;
+    }
+
+    /** FR-16: Return all future (today+) availability slots for the authenticated recruiter. */
+    @Transactional(readOnly = true)
+    public List<AvailabilitySlotResponse> getAvailableSlots(AuthenticatedUser principal) {
+        return slotRepository
+                .findByRecruiterIdAndSlotDateGreaterThanEqualOrderBySlotDateAscStartTimeAsc(
+                        principal.id(), LocalDate.now())
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private AvailabilitySlotResponse toResponse(AvailabilitySlot slot) {
+        return new AvailabilitySlotResponse(
+                slot.getId(),
+                slot.getSlotDate(),
+                slot.getStartTime(),
+                slot.getEndTime(),
+                slot.isBooked()
+        );
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/ExamService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ExamService.java
@@ -1,0 +1,190 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.BatchAuthorizeRequest;
+import com.eaa.recruit.dto.application.BatchAuthorizeResponse;
+import com.eaa.recruit.dto.exam.CreateExamRequest;
+import com.eaa.recruit.dto.exam.CreateExamResponse;
+import com.eaa.recruit.dto.exam.QuestionRequest;
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.messaging.KafkaEventPublisher;
+import com.eaa.recruit.messaging.event.ExamBatchReadyEvent;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.ExamRepository;
+import com.eaa.recruit.repository.JobPostingRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ExamService {
+
+    private static final Logger log = LoggerFactory.getLogger(ExamService.class);
+
+    private final ExamRepository            examRepository;
+    private final JobPostingRepository      jobPostingRepository;
+    private final ApplicationRepository     applicationRepository;
+    private final CandidateNotificationPort candidateNotificationPort;
+    private final KafkaEventPublisher       kafkaEventPublisher;
+    private final ObjectMapper              objectMapper;
+
+    public ExamService(ExamRepository examRepository,
+                       JobPostingRepository jobPostingRepository,
+                       ApplicationRepository applicationRepository,
+                       CandidateNotificationPort candidateNotificationPort,
+                       KafkaEventPublisher kafkaEventPublisher,
+                       ObjectMapper objectMapper) {
+        this.examRepository            = examRepository;
+        this.jobPostingRepository      = jobPostingRepository;
+        this.applicationRepository     = applicationRepository;
+        this.candidateNotificationPort = candidateNotificationPort;
+        this.kafkaEventPublisher       = kafkaEventPublisher;
+        this.objectMapper              = objectMapper;
+    }
+
+    /** FR-24: Create exam definition for a job posting. */
+    @Transactional
+    public CreateExamResponse createExam(Long jobId,
+                                          CreateExamRequest request,
+                                          AuthenticatedUser principal) {
+        JobPosting job = jobPostingRepository.findByIdAndCreatedById(jobId, principal.id())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Job not found or does not belong to you: " + jobId));
+
+        if (examRepository.existsByJobId(jobId)) {
+            throw new ConflictException("An exam already exists for job: " + jobId);
+        }
+
+        Exam exam = Exam.create(job, request.title(), request.durationMinutes());
+
+        int order = 1;
+        for (QuestionRequest qr : request.questions()) {
+            validateQuestionRequest(qr);
+            String optionsJson = serializeOptions(qr);
+            Question question = Question.create(
+                    exam, qr.type(), qr.questionText(),
+                    optionsJson, qr.correctAnswer(),
+                    qr.marks(), order++);
+            exam.addQuestion(question);
+        }
+
+        exam = examRepository.save(exam);
+        log.info("Exam created id={} jobId={} questions={}", exam.getId(), jobId, exam.getQuestions().size());
+
+        return new CreateExamResponse(
+                exam.getId(),
+                jobId,
+                exam.getTitle(),
+                exam.getDurationMinutes(),
+                exam.getQuestions().size()
+        );
+    }
+
+    /** FR-25: Authorize a batch of candidates for the exam. */
+    @Transactional
+    public BatchAuthorizeResponse authorizeExamBatch(Long jobId,
+                                                      BatchAuthorizeRequest request,
+                                                      AuthenticatedUser principal) {
+        jobPostingRepository.findByIdAndCreatedById(jobId, principal.id())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Job not found or does not belong to you: " + jobId));
+
+        Exam exam = examRepository.findByJobId(jobId)
+                .orElseThrow(() -> new BusinessException("No exam defined for job: " + jobId));
+
+        List<Long>                           authorizedIds = new ArrayList<>();
+        List<BatchAuthorizeResponse.SkippedEntry> skipped  = new ArrayList<>();
+
+        for (Long appId : request.applicationIds()) {
+            Application application = applicationRepository.findById(appId).orElse(null);
+
+            if (application == null) {
+                skipped.add(new BatchAuthorizeResponse.SkippedEntry(appId, "Application not found"));
+                continue;
+            }
+            if (!application.getJob().getId().equals(jobId)) {
+                skipped.add(new BatchAuthorizeResponse.SkippedEntry(appId, "Application does not belong to this job"));
+                continue;
+            }
+            if (application.getStatus() != ApplicationStatus.AI_SCREENING) {
+                skipped.add(new BatchAuthorizeResponse.SkippedEntry(appId,
+                        "Status is " + application.getStatus() + " — expected AI_SCREENING"));
+                continue;
+            }
+
+            String token = UUID.randomUUID().toString();
+            application.authorizeExam(token);
+            applicationRepository.save(application);
+
+            User candidate = application.getCandidate();
+            candidateNotificationPort.notifyExamAuthorized(
+                    candidate.getEmail(), candidate.getFullName(),
+                    application.getJob().getTitle(), token);
+
+            authorizedIds.add(appId);
+            log.info("Exam authorized applicationId={} candidateId={}", appId, candidate.getId());
+        }
+
+        if (!authorizedIds.isEmpty()) {
+            publishExamBatchReady(exam, jobId, authorizedIds);
+        }
+
+        return new BatchAuthorizeResponse(authorizedIds.size(), authorizedIds, skipped);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void validateQuestionRequest(QuestionRequest qr) {
+        if (qr.type() == QuestionType.MCQ) {
+            if (qr.options() == null || qr.options().size() < 2) {
+                throw new BusinessException("MCQ questions must have at least 2 options");
+            }
+            if (qr.correctAnswer() == null) {
+                throw new BusinessException("MCQ questions must have a correctAnswer");
+            }
+            if (qr.correctAnswer() < 0 || qr.correctAnswer() >= qr.options().size()) {
+                throw new BusinessException("correctAnswer index is out of range");
+            }
+        }
+    }
+
+    private String serializeOptions(QuestionRequest qr) {
+        if (qr.options() == null || qr.options().isEmpty()) return null;
+        try {
+            return objectMapper.writeValueAsString(qr.options());
+        } catch (JsonProcessingException e) {
+            throw new BusinessException("Could not serialize question options");
+        }
+    }
+
+    private void publishExamBatchReady(Exam exam, Long jobId, List<Long> applicationIds) {
+        List<Long> candidateIds = applicationIds.stream()
+                .map(appId -> applicationRepository.findById(appId)
+                        .map(a -> a.getCandidate().getId())
+                        .orElse(null))
+                .filter(id -> id != null)
+                .toList();
+
+        ExamBatchReadyEvent event = ExamBatchReadyEvent.of(
+                exam.getId(), jobId, candidateIds,
+                exam.getDurationMinutes(), Instant.now());
+
+        try {
+            kafkaEventPublisher.publishExamBatchReady(event);
+        } catch (Exception e) {
+            log.error("Failed to publish EXAM_BATCH_READY for examId={}: {}", exam.getId(), e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/FileStorageService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/FileStorageService.java
@@ -1,0 +1,73 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.config.StorageProperties;
+import com.eaa.recruit.exception.BusinessException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class FileStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileStorageService.class);
+    private static final long   MAX_SIZE_BYTES = 5 * 1024 * 1024L; // 5 MB
+    private static final Set<String> ALLOWED_TYPES = Set.of(
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    );
+
+    private final Path uploadRoot;
+
+    public FileStorageService(StorageProperties properties) {
+        this.uploadRoot = Paths.get(properties.getCvUploadDir()).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(uploadRoot);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not create CV upload directory: " + uploadRoot, e);
+        }
+    }
+
+    /**
+     * Validates and stores a CV file.
+     *
+     * @return storage path relative to upload root (e.g. "uuid.pdf")
+     * @throws BusinessException if the file is invalid
+     * @throws org.springframework.web.multipart.MaxUploadSizeExceededException propagates from Spring
+     */
+    public String storeCv(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException("CV file must not be empty");
+        }
+        if (file.getSize() > MAX_SIZE_BYTES) {
+            throw new BusinessException("CV file exceeds the 5 MB limit");
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_TYPES.contains(contentType)) {
+            throw new BusinessException("CV must be a PDF or DOCX file");
+        }
+
+        String original  = file.getOriginalFilename();
+        String extension = (original != null && original.contains("."))
+                ? original.substring(original.lastIndexOf('.'))
+                : ".pdf";
+        String filename  = UUID.randomUUID() + extension;
+        Path   target    = uploadRoot.resolve(filename);
+
+        try {
+            Files.copy(file.getInputStream(), target);
+            log.debug("Stored CV file='{}'", target);
+            return filename;
+        } catch (IOException e) {
+            log.error("Failed to store CV file: {}", e.getMessage(), e);
+            throw new BusinessException("Could not store CV file — please retry");
+        }
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/HardFilterService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/HardFilterService.java
@@ -1,0 +1,70 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class HardFilterService {
+
+    private static final Logger log = LoggerFactory.getLogger(HardFilterService.class);
+
+    private final ApplicationRepository       applicationRepository;
+    private final CandidateNotificationPort   candidateNotificationPort;
+
+    public HardFilterService(ApplicationRepository applicationRepository,
+                              CandidateNotificationPort candidateNotificationPort) {
+        this.applicationRepository     = applicationRepository;
+        this.candidateNotificationPort = candidateNotificationPort;
+    }
+
+    /**
+     * FR-22: Evaluate candidate profile against job hard-filter criteria.
+     * Runs after AI score callback. Saves updated application state.
+     * Candidates with null profile fields fail the filter.
+     */
+    @Transactional
+    public void applyHardFilter(Application application) {
+        User       candidate = application.getCandidate();
+        JobPosting job       = application.getJob();
+
+        boolean passed = passesHeightCheck(candidate, job)
+                      && passesWeightCheck(candidate, job)
+                      && passesDegreeCheck(candidate, job);
+
+        if (passed) {
+            application.markHardFilterPassed();
+            log.info("Hard filter PASSED applicationId={}", application.getId());
+        } else {
+            application.markHardFilterFailed();
+            log.info("Hard filter FAILED applicationId={}", application.getId());
+            candidateNotificationPort.notifyHardFilterFailed(
+                    candidate.getEmail(),
+                    candidate.getFullName(),
+                    job.getTitle());
+        }
+
+        applicationRepository.save(application);
+    }
+
+    private boolean passesHeightCheck(User candidate, JobPosting job) {
+        if (candidate.getHeightCm() == null) return false;
+        return candidate.getHeightCm() >= job.getMinHeightCm();
+    }
+
+    private boolean passesWeightCheck(User candidate, JobPosting job) {
+        if (candidate.getWeightKg() == null) return false;
+        return candidate.getWeightKg() >= job.getMinWeightKg();
+    }
+
+    private boolean passesDegreeCheck(User candidate, JobPosting job) {
+        if (candidate.getDegree() == null) return false;
+        return candidate.getDegree().equalsIgnoreCase(job.getRequiredDegree());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/JobService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/JobService.java
@@ -1,0 +1,71 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.job.CreateJobRequest;
+import com.eaa.recruit.dto.job.CreateJobResponse;
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.JobPostingRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class JobService {
+
+    private static final Logger log = LoggerFactory.getLogger(JobService.class);
+
+    private final JobPostingRepository jobPostingRepository;
+    private final UserRepository       userRepository;
+
+    public JobService(JobPostingRepository jobPostingRepository,
+                      UserRepository userRepository) {
+        this.jobPostingRepository = jobPostingRepository;
+        this.userRepository       = userRepository;
+    }
+
+    @Transactional
+    public CreateJobResponse createJob(CreateJobRequest request, AuthenticatedUser principal) {
+        validateDateOrdering(request);
+
+        User recruiter = userRepository.findById(principal.id())
+                .orElseThrow(() -> new ResourceNotFoundException("Recruiter not found"));
+
+        JobPosting job = JobPosting.create(
+                request.title(),
+                request.description(),
+                request.minHeightCm(),
+                request.minWeightKg(),
+                request.requiredDegree(),
+                request.openDate(),
+                request.closeDate(),
+                request.examDate(),
+                recruiter
+        );
+
+        job = jobPostingRepository.save(job);
+        log.info("Job posting created id={} title='{}' by recruiterId={}", job.getId(), job.getTitle(), principal.id());
+
+        return new CreateJobResponse(
+                job.getId(),
+                job.getTitle(),
+                job.getStatus(),
+                job.getOpenDate(),
+                job.getCloseDate(),
+                job.getExamDate()
+        );
+    }
+
+    private void validateDateOrdering(CreateJobRequest request) {
+        if (!request.closeDate().isAfter(request.openDate())) {
+            throw new BusinessException("closeDate must be after openDate");
+        }
+        if (!request.examDate().isAfter(request.closeDate())) {
+            throw new BusinessException("examDate must be after closeDate");
+        }
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/RecruiterDashboardService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/RecruiterDashboardService.java
@@ -1,0 +1,44 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.recruiter.DashboardEntryResponse;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.projection.DashboardProjection;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class RecruiterDashboardService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public RecruiterDashboardService(ApplicationRepository applicationRepository) {
+        this.applicationRepository = applicationRepository;
+    }
+
+    /** FR-17: Paginated dashboard showing application counts per job for the recruiter. */
+    @Transactional(readOnly = true)
+    public Page<DashboardEntryResponse> getDashboard(AuthenticatedUser principal, Pageable pageable) {
+        Page<DashboardProjection> projections =
+                applicationRepository.findDashboardByRecruiterId(principal.id(), pageable);
+
+        List<DashboardEntryResponse> entries = projections.getContent().stream()
+                .map(p -> new DashboardEntryResponse(
+                        p.getJobId(),
+                        p.getJobTitle(),
+                        p.getTotalApplications(),
+                        p.getScreeningCount(),
+                        p.getExamCount(),
+                        p.getInterviewCount(),
+                        p.getDecidedCount()
+                ))
+                .toList();
+
+        return new PageImpl<>(entries, pageable, projections.getTotalElements());
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -77,6 +77,11 @@ spring:
     enabled: true
     locations: classpath:db/migration
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 10MB
+
 management:
   endpoints:
     web:
@@ -97,3 +102,13 @@ otp:
   ttl-seconds: ${OTP_TTL_SECONDS:300}
   length: ${OTP_LENGTH:6}
   key-prefix: "otp:"
+
+storage:
+  cv-upload-dir: ${CV_UPLOAD_DIR:./cv-uploads}
+
+internal:
+  api-key: ${INTERNAL_API_KEY:change-me-internal-key}
+
+scheduler:
+  job-status:
+    cron: ${SCHEDULER_JOB_STATUS_CRON:0 * * * * *}

--- a/backend/src/main/resources/db/migration/V3__create_job_postings_table.sql
+++ b/backend/src/main/resources/db/migration/V3__create_job_postings_table.sql
@@ -1,0 +1,26 @@
+-- V3: Job postings table
+
+CREATE TABLE job_postings (
+    id               BIGSERIAL     PRIMARY KEY,
+    title            VARCHAR(255)  NOT NULL,
+    description      TEXT          NOT NULL,
+    min_height_cm    INTEGER       NOT NULL,
+    min_weight_kg    INTEGER       NOT NULL,
+    required_degree  VARCHAR(100)  NOT NULL,
+    open_date        DATE          NOT NULL,
+    close_date       DATE          NOT NULL,
+    exam_date        DATE          NOT NULL,
+    status           VARCHAR(20)   NOT NULL
+                       CHECK (status IN ('DRAFT', 'OPEN', 'CLOSED', 'EXAM_SCHEDULED')),
+    created_by_id    BIGINT        NOT NULL REFERENCES users(id),
+    created_at       TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    version          BIGINT        NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_job_postings_status     ON job_postings (status);
+CREATE INDEX idx_job_postings_created_by ON job_postings (created_by_id);
+
+CREATE TRIGGER trg_job_postings_updated_at
+    BEFORE UPDATE ON job_postings
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/backend/src/main/resources/db/migration/V4__create_applications_table.sql
+++ b/backend/src/main/resources/db/migration/V4__create_applications_table.sql
@@ -1,0 +1,41 @@
+-- V4: Applications table + candidate profile fields on users
+
+-- Candidate profile fields (nullable — only populated for CANDIDATE role)
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS phone      VARCHAR(20),
+    ADD COLUMN IF NOT EXISTS height_cm  INTEGER,
+    ADD COLUMN IF NOT EXISTS weight_kg  INTEGER,
+    ADD COLUMN IF NOT EXISTS degree     VARCHAR(100);
+
+CREATE TABLE applications (
+    id                   BIGSERIAL        PRIMARY KEY,
+    candidate_id         BIGINT           NOT NULL REFERENCES users(id),
+    job_id               BIGINT           NOT NULL REFERENCES job_postings(id),
+    cv_file_path         VARCHAR(500)     NOT NULL,
+    cv_relevance_score   DOUBLE PRECISION,
+    exam_score           DOUBLE PRECISION,
+    hard_filter_passed   BOOLEAN,
+    final_score          DOUBLE PRECISION,
+    status               VARCHAR(30)      NOT NULL DEFAULT 'SUBMITTED'
+                           CHECK (status IN (
+                               'SUBMITTED', 'AI_SCREENING', 'HARD_FILTER_FAILED',
+                               'EXAM_AUTHORIZED', 'EXAM_COMPLETED',
+                               'SHORTLISTED', 'INTERVIEW_SCHEDULED',
+                               'SELECTED', 'REJECTED', 'WAITLISTED'
+                           )),
+    xai_report_url       VARCHAR(500),
+    exam_token           VARCHAR(36),
+    submitted_at         TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    created_at           TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    version              BIGINT           NOT NULL DEFAULT 0,
+    UNIQUE (candidate_id, job_id)
+);
+
+CREATE INDEX idx_applications_candidate ON applications (candidate_id);
+CREATE INDEX idx_applications_job       ON applications (job_id);
+CREATE INDEX idx_applications_status    ON applications (status);
+
+CREATE TRIGGER trg_applications_updated_at
+    BEFORE UPDATE ON applications
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/backend/src/main/resources/db/migration/V5__create_availability_slots_table.sql
+++ b/backend/src/main/resources/db/migration/V5__create_availability_slots_table.sql
@@ -1,0 +1,21 @@
+-- V5: Recruiter interview availability slots
+
+CREATE TABLE availability_slots (
+    id            BIGSERIAL     PRIMARY KEY,
+    recruiter_id  BIGINT        NOT NULL REFERENCES users(id),
+    slot_date     DATE          NOT NULL,
+    start_time    TIME          NOT NULL,
+    end_time      TIME          NOT NULL,
+    is_booked     BOOLEAN       NOT NULL DEFAULT FALSE,
+    created_at    TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    version       BIGINT        NOT NULL DEFAULT 0,
+    CONSTRAINT chk_slot_times CHECK (end_time > start_time)
+);
+
+CREATE INDEX idx_slots_recruiter ON availability_slots (recruiter_id);
+CREATE INDEX idx_slots_date      ON availability_slots (slot_date);
+
+CREATE TRIGGER trg_availability_slots_updated_at
+    BEFORE UPDATE ON availability_slots
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/backend/src/main/resources/db/migration/V6__create_exams_tables.sql
+++ b/backend/src/main/resources/db/migration/V6__create_exams_tables.sql
@@ -1,0 +1,35 @@
+-- V6: Exams and questions
+
+CREATE TABLE exams (
+    id               BIGSERIAL     PRIMARY KEY,
+    job_id           BIGINT        NOT NULL UNIQUE REFERENCES job_postings(id),
+    title            VARCHAR(255)  NOT NULL,
+    duration_minutes INTEGER       NOT NULL CHECK (duration_minutes > 0),
+    created_at       TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    version          BIGINT        NOT NULL DEFAULT 0
+);
+
+CREATE TRIGGER trg_exams_updated_at
+    BEFORE UPDATE ON exams
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TABLE questions (
+    id              BIGSERIAL     PRIMARY KEY,
+    exam_id         BIGINT        NOT NULL REFERENCES exams(id),
+    type            VARCHAR(20)   NOT NULL CHECK (type IN ('MCQ', 'SHORT_ANSWER')),
+    question_text   TEXT          NOT NULL,
+    options         TEXT,
+    correct_answer  INTEGER,
+    marks           INTEGER       NOT NULL CHECK (marks > 0),
+    display_order   INTEGER       NOT NULL,
+    created_at      TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    version         BIGINT        NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_questions_exam ON questions (exam_id, display_order);
+
+CREATE TRIGGER trg_questions_updated_at
+    BEFORE UPDATE ON questions
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/backend/src/test/java/com/eaa/recruit/controller/AdminUserControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/AdminUserControllerTest.java
@@ -1,11 +1,13 @@
 package com.eaa.recruit.controller;
 
+import com.eaa.recruit.cache.BlockedUserCacheService;
 import com.eaa.recruit.config.SecurityConfig;
 import com.eaa.recruit.dto.admin.RecruiterCreatedResponse;
 import com.eaa.recruit.exception.ConflictException;
 import com.eaa.recruit.exception.GlobalExceptionHandler;
 import com.eaa.recruit.security.*;
 import com.eaa.recruit.service.RecruiterAdminService;
+import com.eaa.recruit.service.UserStatusService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -34,8 +36,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class AdminUserControllerTest {
 
     @Autowired MockMvc mockMvc;
-    @MockBean  RecruiterAdminService recruiterAdminService;
-    @MockBean  UserDetailsServiceImpl userDetailsService;
+    @MockBean  RecruiterAdminService   recruiterAdminService;
+    @MockBean  UserStatusService       userStatusService;
+    @MockBean  UserDetailsServiceImpl  userDetailsService;
+    @MockBean  BlockedUserCacheService blockedUserCacheService;
 
     private static final String VALID_BODY = """
             {

--- a/backend/src/test/java/com/eaa/recruit/controller/AdminUserStatusControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/AdminUserStatusControllerTest.java
@@ -1,5 +1,6 @@
 package com.eaa.recruit.controller;
 
+import com.eaa.recruit.cache.BlockedUserCacheService;
 import com.eaa.recruit.config.SecurityConfig;
 import com.eaa.recruit.exception.BusinessException;
 import com.eaa.recruit.exception.GlobalExceptionHandler;
@@ -38,6 +39,7 @@ class AdminUserStatusControllerTest {
     @MockBean  UserStatusService       userStatusService;
     @MockBean  RecruiterAdminService   recruiterAdminService;
     @MockBean  UserDetailsServiceImpl  userDetailsService;
+    @MockBean  BlockedUserCacheService blockedUserCacheService;
 
     // ── RBAC ─────────────────────────────────────────────────────────────────
 

--- a/backend/src/test/java/com/eaa/recruit/controller/ApplicationControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/ApplicationControllerTest.java
@@ -1,0 +1,112 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.cache.BlockedUserCacheService;
+import com.eaa.recruit.config.SecurityConfig;
+import com.eaa.recruit.dto.application.SubmitApplicationResponse;
+import com.eaa.recruit.entity.ApplicationStatus;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.GlobalExceptionHandler;
+import com.eaa.recruit.security.*;
+import com.eaa.recruit.service.ApplicationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ApplicationController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class,
+         JwtAuthenticationFilter.class, JwtTokenProvider.class,
+         JwtProperties.class, JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class ApplicationControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean  ApplicationService      applicationService;
+    @MockBean  UserDetailsServiceImpl  userDetailsService;
+    @MockBean  BlockedUserCacheService blockedUserCacheService;
+
+    private static final MockMultipartFile CV_FILE =
+            new MockMultipartFile("cv", "cv.pdf", "application/pdf", new byte[100]);
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void unauthenticated_returns401() throws Exception {
+        mockMvc.perform(multipart("/api/v1/applications")
+                        .file(CV_FILE)
+                        .param("jobId", "1"))
+               .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void recruiter_returns403() throws Exception {
+        mockMvc.perform(multipart("/api/v1/applications")
+                        .file(CV_FILE)
+                        .param("jobId", "1"))
+               .andExpect(status().isForbidden());
+    }
+
+    // ── Success ───────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "CANDIDATE")
+    void candidate_returns201_onSuccess() throws Exception {
+        when(applicationService.submitApplication(any(), any(), any()))
+                .thenReturn(new SubmitApplicationResponse(1L, 1L, ApplicationStatus.SUBMITTED, Instant.now()));
+
+        mockMvc.perform(multipart("/api/v1/applications")
+                        .file(CV_FILE)
+                        .param("jobId", "1")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+               .andExpect(status().isCreated())
+               .andExpect(jsonPath("$.status").value("success"))
+               .andExpect(jsonPath("$.data.status").value("SUBMITTED"));
+    }
+
+    // ── Error cases ───────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "CANDIDATE")
+    void closedJob_returns400() throws Exception {
+        when(applicationService.submitApplication(any(), any(), any()))
+                .thenThrow(new BusinessException("Applications are only accepted for OPEN jobs"));
+
+        mockMvc.perform(multipart("/api/v1/applications")
+                        .file(CV_FILE)
+                        .param("jobId", "1"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.message").value("Applications are only accepted for OPEN jobs"));
+    }
+
+    @Test
+    @WithMockUser(roles = "CANDIDATE")
+    void duplicateApplication_returns409() throws Exception {
+        when(applicationService.submitApplication(any(), any(), any()))
+                .thenThrow(new ConflictException("You have already applied for this job"));
+
+        mockMvc.perform(multipart("/api/v1/applications")
+                        .file(CV_FILE)
+                        .param("jobId", "1"))
+               .andExpect(status().isConflict());
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.eaa.recruit.controller;
 
+import com.eaa.recruit.cache.BlockedUserCacheService;
 import com.eaa.recruit.config.SecurityConfig;
 import com.eaa.recruit.dto.auth.RegistrationResponse;
 import com.eaa.recruit.exception.BusinessException;
@@ -40,7 +41,8 @@ class AuthControllerTest {
 
     @Autowired MockMvc mockMvc;
     @MockBean  CandidateRegistrationService registrationService;
-    @MockBean  UserDetailsServiceImpl userDetailsService;
+    @MockBean  UserDetailsServiceImpl       userDetailsService;
+    @MockBean  BlockedUserCacheService      blockedUserCacheService;
 
     private static final String VALID_BODY = """
             {

--- a/backend/src/test/java/com/eaa/recruit/controller/ExamControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/ExamControllerTest.java
@@ -1,0 +1,133 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.cache.BlockedUserCacheService;
+import com.eaa.recruit.config.SecurityConfig;
+import com.eaa.recruit.dto.application.BatchAuthorizeResponse;
+import com.eaa.recruit.dto.exam.CreateExamResponse;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.GlobalExceptionHandler;
+import com.eaa.recruit.security.*;
+import com.eaa.recruit.service.ExamService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ExamController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class,
+         JwtAuthenticationFilter.class, JwtTokenProvider.class,
+         JwtProperties.class, JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class ExamControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean  ExamService             examService;
+    @MockBean  UserDetailsServiceImpl  userDetailsService;
+    @MockBean  BlockedUserCacheService blockedUserCacheService;
+
+    private static final String VALID_EXAM_BODY = """
+            {
+              "title": "Pilot Exam",
+              "durationMinutes": 60,
+              "questions": [
+                {
+                  "type": "MCQ",
+                  "questionText": "What is ICAO?",
+                  "options": ["A", "B", "C", "D"],
+                  "correctAnswer": 0,
+                  "marks": 5
+                }
+              ]
+            }
+            """;
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs/1/exam")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_EXAM_BODY))
+               .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "CANDIDATE")
+    void candidate_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs/1/exam")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_EXAM_BODY))
+               .andExpect(status().isForbidden());
+    }
+
+    // ── createExam ────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void createExam_returns201_onSuccess() throws Exception {
+        when(examService.createExam(eq(1L), any(), any()))
+                .thenReturn(new CreateExamResponse(10L, 1L, "Pilot Exam", 60, 1));
+
+        mockMvc.perform(post("/api/v1/jobs/1/exam")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_EXAM_BODY))
+               .andExpect(status().isCreated())
+               .andExpect(jsonPath("$.data.examId").value(10))
+               .andExpect(jsonPath("$.data.questionCount").value(1));
+    }
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void createExam_returns409_whenDuplicate() throws Exception {
+        when(examService.createExam(any(), any(), any()))
+                .thenThrow(new ConflictException("An exam already exists for job: 1"));
+
+        mockMvc.perform(post("/api/v1/jobs/1/exam")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_EXAM_BODY))
+               .andExpect(status().isConflict());
+    }
+
+    // ── authorizeExamBatch ────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void authorizeExamBatch_returns200_withResults() throws Exception {
+        when(examService.authorizeExamBatch(eq(1L), any(), any()))
+                .thenReturn(new BatchAuthorizeResponse(2, List.of(1L, 2L), List.of()));
+
+        mockMvc.perform(post("/api/v1/jobs/1/exam/authorize")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"applicationIds\":[1,2]}"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.data.authorizedCount").value(2))
+               .andExpect(jsonPath("$.data.skipped").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void authorizeExamBatch_returns400_whenNoIds() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs/1/exam/authorize")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"applicationIds\":[]}"))
+               .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/controller/JobControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/JobControllerTest.java
@@ -1,0 +1,157 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.cache.BlockedUserCacheService;
+import com.eaa.recruit.config.SecurityConfig;
+import com.eaa.recruit.dto.job.CreateJobResponse;
+import com.eaa.recruit.entity.JobPostingStatus;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.GlobalExceptionHandler;
+import com.eaa.recruit.security.*;
+import com.eaa.recruit.service.JobService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(JobController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class,
+         JwtAuthenticationFilter.class, JwtTokenProvider.class,
+         JwtProperties.class, JwtAuthEntryPoint.class, JwtAccessDeniedHandler.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-testing-purposes",
+    "jwt.expiration-ms=3600000"
+})
+class JobControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean  JobService              jobService;
+    @MockBean  UserDetailsServiceImpl  userDetailsService;
+    @MockBean  BlockedUserCacheService blockedUserCacheService;
+
+    private static final LocalDate OPEN  = LocalDate.now().plusDays(1);
+    private static final LocalDate CLOSE = OPEN.plusDays(30);
+    private static final LocalDate EXAM  = CLOSE.plusDays(7);
+
+    private String validBody() {
+        return """
+                {
+                  "title": "Pilot",
+                  "description": "Fly planes",
+                  "minHeightCm": 170,
+                  "minWeightKg": 60,
+                  "requiredDegree": "BSc Aviation",
+                  "openDate": "%s",
+                  "closeDate": "%s",
+                  "examDate": "%s"
+                }
+                """.formatted(OPEN, CLOSE, EXAM);
+    }
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody()))
+               .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "CANDIDATE")
+    void candidate_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody()))
+               .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void admin_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody()))
+               .andExpect(status().isForbidden());
+    }
+
+    // ── Success ───────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void recruiter_returns201_onSuccess() throws Exception {
+        when(jobService.createJob(any(), any()))
+                .thenReturn(new CreateJobResponse(1L, "Pilot", JobPostingStatus.DRAFT, OPEN, CLOSE, EXAM));
+
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody()))
+               .andExpect(status().isCreated())
+               .andExpect(jsonPath("$.status").value("success"))
+               .andExpect(jsonPath("$.data.id").value(1))
+               .andExpect(jsonPath("$.data.status").value("DRAFT"));
+    }
+
+    // ── Validation ────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void missingTitle_returns400() throws Exception {
+        String body = """
+                {
+                  "description": "desc",
+                  "minHeightCm": 170,
+                  "minWeightKg": 60,
+                  "requiredDegree": "BSc",
+                  "openDate": "%s",
+                  "closeDate": "%s",
+                  "examDate": "%s"
+                }
+                """.formatted(OPEN, CLOSE, EXAM);
+
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.errors[?(@.field=='title')]").exists());
+    }
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void missingDates_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title":"Pilot","description":"desc","minHeightCm":170,"minWeightKg":60,"requiredDegree":"BSc"}
+                                """))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.errors").isArray());
+    }
+
+    @Test
+    @WithMockUser(roles = "RECRUITER")
+    void invalidDateOrdering_returns400() throws Exception {
+        when(jobService.createJob(any(), any()))
+                .thenThrow(new BusinessException("closeDate must be after openDate"));
+
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody()))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.message").value("closeDate must be after openDate"));
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/entity/JobPostingTest.java
+++ b/backend/src/test/java/com/eaa/recruit/entity/JobPostingTest.java
@@ -2,16 +2,23 @@ package com.eaa.recruit.entity;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JobPostingTest {
+
+    private static final LocalDate OPEN  = LocalDate.now().plusDays(1);
+    private static final LocalDate CLOSE = OPEN.plusDays(30);
+    private static final LocalDate EXAM  = CLOSE.plusDays(7);
 
     private User recruiter() {
         return User.create("recruiter@eaa.com", "hash", Role.RECRUITER, "Alice");
     }
 
     private JobPosting posting() {
-        return JobPosting.create("Pilot", "Fly planes", 170, 60, "BSc Aviation", recruiter());
+        return JobPosting.create("Pilot", "Fly planes", 170, 60, "BSc Aviation",
+                OPEN, CLOSE, EXAM, recruiter());
     }
 
     @Test void newPosting_statusIsDraft() {
@@ -45,6 +52,9 @@ class JobPostingTest {
         assertThat(jp.getMinHeightCm()).isEqualTo(170);
         assertThat(jp.getMinWeightKg()).isEqualTo(60);
         assertThat(jp.getRequiredDegree()).isEqualTo("BSc Aviation");
+        assertThat(jp.getOpenDate()).isEqualTo(OPEN);
+        assertThat(jp.getCloseDate()).isEqualTo(CLOSE);
+        assertThat(jp.getExamDate()).isEqualTo(EXAM);
         assertThat(jp.getCreatedBy().getRole()).isEqualTo(Role.RECRUITER);
     }
 }

--- a/backend/src/test/java/com/eaa/recruit/repository/JobPostingRepositoryTest.java
+++ b/backend/src/test/java/com/eaa/recruit/repository/JobPostingRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,6 +24,10 @@ class JobPostingRepositoryTest {
 
     @Autowired JobPostingRepository jobPostingRepository;
     @Autowired UserRepository userRepository;
+
+    private static final LocalDate OPEN  = LocalDate.now().plusDays(1);
+    private static final LocalDate CLOSE = OPEN.plusDays(30);
+    private static final LocalDate EXAM  = CLOSE.plusDays(7);
 
     private User recruiter;
 
@@ -36,7 +41,7 @@ class JobPostingRepositoryTest {
     @Test
     void saveAndFindById() {
         JobPosting saved = jobPostingRepository.save(
-            JobPosting.create("Pilot", "Fly planes", 170, 60, "BSc Aviation", recruiter)
+            JobPosting.create("Pilot", "Fly planes", 170, 60, "BSc Aviation", OPEN, CLOSE, EXAM, recruiter)
         );
 
         assertThat(saved.getId()).isNotNull();
@@ -47,10 +52,10 @@ class JobPostingRepositoryTest {
     @Test
     void findByStatus_returnsMatchingPostings() {
         JobPosting draft = jobPostingRepository.save(
-            JobPosting.create("Draft Job", "desc", 165, 55, "BSc", recruiter)
+            JobPosting.create("Draft Job", "desc", 165, 55, "BSc", OPEN, CLOSE, EXAM, recruiter)
         );
         JobPosting open = jobPostingRepository.save(
-            JobPosting.create("Open Job", "desc", 165, 55, "BSc", recruiter)
+            JobPosting.create("Open Job", "desc", 165, 55, "BSc", OPEN, CLOSE, EXAM, recruiter)
         );
         open.publish();
         jobPostingRepository.save(open);
@@ -67,17 +72,17 @@ class JobPostingRepositoryTest {
     @Test
     void findByCreatedById_returnsRecruiterPostings() {
         jobPostingRepository.save(
-            JobPosting.create("Job A", "desc", 170, 60, "BSc", recruiter)
+            JobPosting.create("Job A", "desc", 170, 60, "BSc", OPEN, CLOSE, EXAM, recruiter)
         );
         jobPostingRepository.save(
-            JobPosting.create("Job B", "desc", 175, 65, "MSc", recruiter)
+            JobPosting.create("Job B", "desc", 175, 65, "MSc", OPEN, CLOSE, EXAM, recruiter)
         );
 
         User other = userRepository.save(
             User.create("other@eaa.com", "hash", Role.RECRUITER, "Bob")
         );
         jobPostingRepository.save(
-            JobPosting.create("Job C", "desc", 160, 50, "BSc", other)
+            JobPosting.create("Job C", "desc", 160, 50, "BSc", OPEN, CLOSE, EXAM, other)
         );
 
         List<JobPosting> mine = jobPostingRepository.findByCreatedById(recruiter.getId());
@@ -87,7 +92,7 @@ class JobPostingRepositoryTest {
     @Test
     void allStatusTransitions_persistCorrectly() {
         JobPosting jp = jobPostingRepository.save(
-            JobPosting.create("Flight Eng", "desc", 168, 58, "BSc", recruiter)
+            JobPosting.create("Flight Eng", "desc", 168, 58, "BSc", OPEN, CLOSE, EXAM, recruiter)
         );
 
         jp.publish();

--- a/backend/src/test/java/com/eaa/recruit/scheduler/JobStatusSchedulerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/scheduler/JobStatusSchedulerTest.java
@@ -1,0 +1,76 @@
+package com.eaa.recruit.scheduler;
+
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.JobPostingStatus;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.repository.JobPostingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobStatusSchedulerTest {
+
+    @Mock JobPostingRepository jobPostingRepository;
+
+    JobStatusScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new JobStatusScheduler(jobPostingRepository);
+    }
+
+    @Test
+    void closeExpiredJobs_closesOpenJobsPastDeadline() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        JobPosting expiredJob = JobPosting.create(
+                "Pilot", "desc", 170, 60, "BSc",
+                yesterday.minusDays(30), yesterday, yesterday.plusDays(7), recruiter);
+        expiredJob.publish(); // make OPEN
+
+        when(jobPostingRepository.findOverdueByStatus(eq(JobPostingStatus.OPEN), any(LocalDate.class)))
+                .thenReturn(List.of(expiredJob));
+
+        scheduler.closeExpiredJobs();
+
+        assertThat(expiredJob.getStatus()).isEqualTo(JobPostingStatus.CLOSED);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<JobPosting>> captor = ArgumentCaptor.forClass(List.class);
+        verify(jobPostingRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).contains(expiredJob);
+    }
+
+    @Test
+    void closeExpiredJobs_doesNothingWhenNoExpiredJobs() {
+        when(jobPostingRepository.findOverdueByStatus(any(), any())).thenReturn(List.of());
+
+        scheduler.closeExpiredJobs();
+
+        verify(jobPostingRepository, never()).saveAll(any());
+    }
+
+    @Test
+    void closeExpiredJobs_isIdempotent() {
+        when(jobPostingRepository.findOverdueByStatus(any(), any())).thenReturn(List.of());
+
+        scheduler.closeExpiredJobs();
+        scheduler.closeExpiredJobs();
+
+        verify(jobPostingRepository, times(2)).findOverdueByStatus(any(), any());
+        verify(jobPostingRepository, never()).saveAll(any());
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
@@ -1,0 +1,122 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.SubmitApplicationResponse;
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.messaging.KafkaEventPublisher;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.JobPostingRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationServiceTest {
+
+    @Mock ApplicationRepository  applicationRepository;
+    @Mock JobPostingRepository   jobPostingRepository;
+    @Mock UserRepository         userRepository;
+    @Mock FileStorageService     fileStorageService;
+    @Mock KafkaEventPublisher    kafkaEventPublisher;
+    @Mock HardFilterService      hardFilterService;
+
+    ApplicationService service;
+
+    private static final AuthenticatedUser CANDIDATE =
+            new AuthenticatedUser(10L, "candidate@eaa.com", "CANDIDATE");
+
+    @BeforeEach
+    void setUp() {
+        service = new ApplicationService(applicationRepository, jobPostingRepository,
+                userRepository, fileStorageService, kafkaEventPublisher, hardFilterService);
+    }
+
+    private static User candidateUser() {
+        return User.create("candidate@eaa.com", "hash", Role.CANDIDATE, "Bob");
+    }
+
+    private static JobPosting openJob(User recruiter) {
+        JobPosting job = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(30),
+                LocalDate.now().plusDays(37),
+                recruiter);
+        job.publish();
+        return job;
+    }
+
+    private static MockMultipartFile validCv() {
+        return new MockMultipartFile("cv", "cv.pdf", "application/pdf", new byte[100]);
+    }
+
+    @Test
+    void submitApplication_createsApplicationAndPublishesEvent() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job = openJob(recruiter);
+        User candidate = candidateUser();
+
+        when(jobPostingRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(applicationRepository.existsByCandidateIdAndJobId(10L, 1L)).thenReturn(false);
+        when(fileStorageService.storeCv(any())).thenReturn("uuid.pdf");
+        when(userRepository.findById(10L)).thenReturn(Optional.of(candidate));
+        when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        SubmitApplicationResponse resp = service.submitApplication(1L, validCv(), CANDIDATE);
+
+        assertThat(resp.jobId()).isEqualTo(1L);
+        assertThat(resp.status()).isEqualTo(ApplicationStatus.SUBMITTED);
+        verify(kafkaEventPublisher).publishCvUploaded(any());
+    }
+
+    @Test
+    void submitApplication_throwsBusinessException_whenJobNotOpen() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting draft = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now().plusDays(1), LocalDate.now().plusDays(30),
+                LocalDate.now().plusDays(37), recruiter);
+        // status is DRAFT, not OPEN
+
+        when(jobPostingRepository.findById(1L)).thenReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> service.submitApplication(1L, validCv(), CANDIDATE))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("OPEN");
+
+        verifyNoInteractions(applicationRepository);
+    }
+
+    @Test
+    void submitApplication_throwsConflictException_onDuplicateApplication() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job = openJob(recruiter);
+
+        when(jobPostingRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(applicationRepository.existsByCandidateIdAndJobId(10L, 1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.submitApplication(1L, validCv(), CANDIDATE))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    void submitApplication_throwsResourceNotFoundException_whenJobMissing() {
+        when(jobPostingRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.submitApplication(99L, validCv(), CANDIDATE))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/ExamServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ExamServiceTest.java
@@ -1,0 +1,134 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.BatchAuthorizeRequest;
+import com.eaa.recruit.dto.application.BatchAuthorizeResponse;
+import com.eaa.recruit.dto.exam.CreateExamRequest;
+import com.eaa.recruit.dto.exam.CreateExamResponse;
+import com.eaa.recruit.dto.exam.QuestionRequest;
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.messaging.KafkaEventPublisher;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.ExamRepository;
+import com.eaa.recruit.repository.JobPostingRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ExamServiceTest {
+
+    @Mock ExamRepository            examRepository;
+    @Mock JobPostingRepository      jobPostingRepository;
+    @Mock ApplicationRepository     applicationRepository;
+    @Mock CandidateNotificationPort candidateNotificationPort;
+    @Mock KafkaEventPublisher       kafkaEventPublisher;
+
+    ExamService service;
+
+    private static final AuthenticatedUser RECRUITER =
+            new AuthenticatedUser(42L, "r@eaa.com", "RECRUITER");
+
+    @BeforeEach
+    void setUp() {
+        service = new ExamService(examRepository, jobPostingRepository, applicationRepository,
+                candidateNotificationPort, kafkaEventPublisher, new ObjectMapper());
+    }
+
+    private static JobPosting job(User recruiter) {
+        return JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now().plusDays(1), LocalDate.now().plusDays(30),
+                LocalDate.now().plusDays(37), recruiter);
+    }
+
+    private static CreateExamRequest validRequest() {
+        return new CreateExamRequest("Pilot Exam", 60, List.of(
+                new QuestionRequest(QuestionType.MCQ, "What is ICAO?",
+                        List.of("A", "B", "C", "D"), 0, 5)
+        ));
+    }
+
+    @Test
+    void createExam_savesExamWithQuestions() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job = job(recruiter);
+
+        when(jobPostingRepository.findByIdAndCreatedById(1L, 42L)).thenReturn(Optional.of(job));
+        when(examRepository.existsByJobId(1L)).thenReturn(false);
+        when(examRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        CreateExamResponse response = service.createExam(1L, validRequest(), RECRUITER);
+
+        assertThat(response.title()).isEqualTo("Pilot Exam");
+        assertThat(response.durationMinutes()).isEqualTo(60);
+        assertThat(response.questionCount()).isEqualTo(1);
+        verify(examRepository).save(any(Exam.class));
+    }
+
+    @Test
+    void createExam_throwsConflict_whenExamExists() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        when(jobPostingRepository.findByIdAndCreatedById(1L, 42L)).thenReturn(Optional.of(job(recruiter)));
+        when(examRepository.existsByJobId(1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.createExam(1L, validRequest(), RECRUITER))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    void createExam_throwsBusinessException_whenMcqMissingOptions() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        when(jobPostingRepository.findByIdAndCreatedById(1L, 42L)).thenReturn(Optional.of(job(recruiter)));
+        when(examRepository.existsByJobId(1L)).thenReturn(false);
+
+        CreateExamRequest badRequest = new CreateExamRequest("Exam", 60, List.of(
+                new QuestionRequest(QuestionType.MCQ, "Question?", null, null, 5)
+        ));
+
+        assertThatThrownBy(() -> service.createExam(1L, badRequest, RECRUITER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("options");
+    }
+
+    @Test
+    void authorizeExamBatch_skipsNonExistentApplications() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job = job(recruiter);
+        Exam exam = Exam.create(job, "Pilot Exam", 60);
+
+        when(jobPostingRepository.findByIdAndCreatedById(1L, 42L)).thenReturn(Optional.of(job));
+        when(examRepository.findByJobId(1L)).thenReturn(Optional.of(exam));
+        when(applicationRepository.findById(99L)).thenReturn(Optional.empty());
+
+        BatchAuthorizeResponse response = service.authorizeExamBatch(
+                1L, new BatchAuthorizeRequest(List.of(99L)), RECRUITER);
+
+        assertThat(response.authorizedCount()).isZero();
+        assertThat(response.skipped()).hasSize(1);
+        assertThat(response.skipped().get(0).reason()).contains("not found");
+    }
+
+    @Test
+    void createExam_throwsResourceNotFoundException_whenJobNotOwned() {
+        when(jobPostingRepository.findByIdAndCreatedById(1L, 42L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createExam(1L, validRequest(), RECRUITER))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/HardFilterServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/HardFilterServiceTest.java
@@ -1,0 +1,111 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HardFilterServiceTest {
+
+    @Mock ApplicationRepository       applicationRepository;
+    @Mock CandidateNotificationPort   candidateNotificationPort;
+
+    HardFilterService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new HardFilterService(applicationRepository, candidateNotificationPort);
+    }
+
+    private static User candidateWithProfile(Integer heightCm, Integer weightKg, String degree) {
+        User u = User.create("c@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        setField(u, "heightCm", heightCm);
+        setField(u, "weightKg", weightKg);
+        setField(u, "degree",   degree);
+        return u;
+    }
+
+    private static JobPosting job() {
+        User recruiter = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        return JobPosting.create("Pilot", "desc", 170, 60, "BSc Aviation",
+                LocalDate.now().plusDays(1), LocalDate.now().plusDays(30),
+                LocalDate.now().plusDays(37), recruiter);
+    }
+
+    private static Application applicationFor(User candidate, JobPosting job) {
+        return Application.create(candidate, job, "cv.pdf");
+    }
+
+    @Test
+    void applyHardFilter_passesWhenAllCriteriaMet() {
+        User candidate = candidateWithProfile(175, 70, "BSc Aviation");
+        Application application = applicationFor(candidate, job());
+        application.applyAiScore(0.8, "http://report");
+
+        service.applyHardFilter(application);
+
+        assertThat(application.getHardFilterPassed()).isTrue();
+        assertThat(application.getStatus()).isEqualTo(ApplicationStatus.AI_SCREENING);
+        verifyNoInteractions(candidateNotificationPort);
+    }
+
+    @Test
+    void applyHardFilter_failsWhenHeightBelowMinimum() {
+        User candidate = candidateWithProfile(160, 70, "BSc Aviation");
+        Application application = applicationFor(candidate, job());
+        application.applyAiScore(0.8, "http://report");
+
+        service.applyHardFilter(application);
+
+        assertThat(application.getHardFilterPassed()).isFalse();
+        assertThat(application.getStatus()).isEqualTo(ApplicationStatus.HARD_FILTER_FAILED);
+        verify(candidateNotificationPort).notifyHardFilterFailed(any(), any(), any());
+    }
+
+    @Test
+    void applyHardFilter_failsWhenNullProfileFields() {
+        User candidate = candidateWithProfile(null, null, null);
+        Application application = applicationFor(candidate, job());
+        application.applyAiScore(0.9, "http://report");
+
+        service.applyHardFilter(application);
+
+        assertThat(application.getHardFilterPassed()).isFalse();
+        assertThat(application.getStatus()).isEqualTo(ApplicationStatus.HARD_FILTER_FAILED);
+        verify(candidateNotificationPort).notifyHardFilterFailed(any(), any(), any());
+    }
+
+    @Test
+    void applyHardFilter_failsWhenDegreeMismatch() {
+        User candidate = candidateWithProfile(180, 75, "BA English");
+        Application application = applicationFor(candidate, job());
+        application.applyAiScore(0.8, "http://report");
+
+        service.applyHardFilter(application);
+
+        assertThat(application.getHardFilterPassed()).isFalse();
+        assertThat(application.getStatus()).isEqualTo(ApplicationStatus.HARD_FILTER_FAILED);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/JobServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/JobServiceTest.java
@@ -1,0 +1,136 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.job.CreateJobRequest;
+import com.eaa.recruit.dto.job.CreateJobResponse;
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.JobPostingStatus;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.JobPostingRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobServiceTest {
+
+    @Mock JobPostingRepository jobPostingRepository;
+    @Mock UserRepository       userRepository;
+
+    JobService service;
+
+    private static final LocalDate OPEN  = LocalDate.now().plusDays(1);
+    private static final LocalDate CLOSE = OPEN.plusDays(30);
+    private static final LocalDate EXAM  = CLOSE.plusDays(7);
+
+    private static final AuthenticatedUser RECRUITER_PRINCIPAL =
+            new AuthenticatedUser(42L, "recruiter@eaa.com", "RECRUITER");
+
+    @BeforeEach
+    void setUp() {
+        service = new JobService(jobPostingRepository, userRepository);
+    }
+
+    private static CreateJobRequest validRequest() {
+        return new CreateJobRequest(
+                "Pilot", "Fly planes", 170, 60, "BSc Aviation",
+                OPEN, CLOSE, EXAM
+        );
+    }
+
+    private static User recruiter() {
+        return User.create("recruiter@eaa.com", "hash", Role.RECRUITER, "Alice");
+    }
+
+    private static JobPosting savedPosting(User recruiter) {
+        return JobPosting.create("Pilot", "Fly planes", 170, 60, "BSc Aviation",
+                OPEN, CLOSE, EXAM, recruiter);
+    }
+
+    @Test
+    void createJob_savesPosting_andReturnsResponse() {
+        User recruiter = recruiter();
+        when(userRepository.findById(42L)).thenReturn(Optional.of(recruiter));
+        when(jobPostingRepository.save(any(JobPosting.class))).thenReturn(savedPosting(recruiter));
+
+        CreateJobResponse response = service.createJob(validRequest(), RECRUITER_PRINCIPAL);
+
+        assertThat(response.title()).isEqualTo("Pilot");
+        assertThat(response.status()).isEqualTo(JobPostingStatus.DRAFT);
+        assertThat(response.openDate()).isEqualTo(OPEN);
+        assertThat(response.closeDate()).isEqualTo(CLOSE);
+        assertThat(response.examDate()).isEqualTo(EXAM);
+    }
+
+    @Test
+    void createJob_persistsCorrectFields() {
+        User recruiter = recruiter();
+        when(userRepository.findById(42L)).thenReturn(Optional.of(recruiter));
+        when(jobPostingRepository.save(any(JobPosting.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.createJob(validRequest(), RECRUITER_PRINCIPAL);
+
+        ArgumentCaptor<JobPosting> captor = ArgumentCaptor.forClass(JobPosting.class);
+        verify(jobPostingRepository).save(captor.capture());
+        JobPosting saved = captor.getValue();
+        assertThat(saved.getTitle()).isEqualTo("Pilot");
+        assertThat(saved.getStatus()).isEqualTo(JobPostingStatus.DRAFT);
+        assertThat(saved.getOpenDate()).isEqualTo(OPEN);
+        assertThat(saved.getCloseDate()).isEqualTo(CLOSE);
+        assertThat(saved.getExamDate()).isEqualTo(EXAM);
+    }
+
+    @Test
+    void createJob_throwsBusinessException_whenCloseDateNotAfterOpenDate() {
+        CreateJobRequest bad = new CreateJobRequest(
+                "Pilot", "desc", 170, 60, "BSc",
+                OPEN, OPEN,        // closeDate == openDate — not after
+                EXAM
+        );
+
+        assertThatThrownBy(() -> service.createJob(bad, RECRUITER_PRINCIPAL))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("closeDate must be after openDate");
+
+        verifyNoInteractions(jobPostingRepository);
+    }
+
+    @Test
+    void createJob_throwsBusinessException_whenExamDateNotAfterCloseDate() {
+        CreateJobRequest bad = new CreateJobRequest(
+                "Pilot", "desc", 170, 60, "BSc",
+                OPEN, CLOSE, CLOSE // examDate == closeDate — not after
+        );
+
+        assertThatThrownBy(() -> service.createJob(bad, RECRUITER_PRINCIPAL))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("examDate must be after closeDate");
+
+        verifyNoInteractions(jobPostingRepository);
+    }
+
+    @Test
+    void createJob_throwsResourceNotFoundException_whenRecruiterMissing() {
+        when(userRepository.findById(42L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createJob(validRequest(), RECRUITER_PRINCIPAL))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verifyNoInteractions(jobPostingRepository);
+    }
+}


### PR DESCRIPTION
## Summary

- **FR-14** `POST /api/v1/jobs` — recruiter creates job posting (DRAFT status)
- **FR-15** `@Scheduled` cron auto-closes OPEN jobs whose `closeDate` has passed
- **FR-16** `POST/GET /api/v1/recruiters/availability` — interview slots with overlap check (409 on conflict)
- **FR-17** `GET /api/v1/recruiters/dashboard` — paginated per-job application counts by pipeline stage
- **FR-18** `Application` entity — 10-status lifecycle, unique `(candidateId, jobId)` constraint
- **FR-19** `POST /api/v1/applications` — multipart CV upload (PDF/DOCX, 5 MB max), local file storage
- **FR-20** `CV_UPLOADED` Kafka event published after successful application submission
- **FR-21** `POST /api/v1/internal/applications/{id}/ai-score` — AI callback secured via `X-Internal-Api-Key`
- **FR-22** Hard filter (height/weight/degree) runs synchronously after AI callback; failures notify candidate
- **FR-23** `Exam` + `Question` entities — supports MCQ (JSON options) and SHORT_ANSWER types
- **FR-24** `POST /api/v1/jobs/{id}/exam` — recruiter defines exam with ordered questions
- **FR-25** `POST /api/v1/jobs/{id}/exam/authorize` — batch auth generates UUID tokens per candidate, publishes `EXAM_BATCH_READY` Kafka event

**Migrations:** V3 (job_postings), V4 (applications + candidate profile fields on users), V5 (availability_slots), V6 (exams + questions)

## Test plan

- [ ] All new unit tests pass: `JobStatusSchedulerTest`, `ApplicationServiceTest`, `HardFilterServiceTest`, `ExamServiceTest`
- [ ] All new controller tests pass (RBAC + happy path): `ApplicationControllerTest`, `ExamControllerTest`, `JobControllerTest`
- [ ] Run against real Postgres + Redis + Kafka via Docker Compose to verify Flyway migrations V3–V6
- [ ] Test CV upload: verify 5 MB limit enforced (413), duplicate application returns 409, closed job returns 400
- [ ] Test hard filter: candidate with missing profile fields gets `HARD_FILTER_FAILED`
- [ ] Test batch authorization: only `AI_SCREENING` candidates authorized; others appear in `skipped` list
- [ ] Test scheduler: job with `closeDate` in past transitions from `OPEN` → `CLOSED` on next cron tick