### PR TITLE
feat(backend): pipeline finalization FR-26–40

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -64,4 +64,5 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    jvmArgs '-Dnet.bytebuddy.experimental=true'
 }

--- a/backend/src/main/java/com/eaa/recruit/config/KafkaConfig.java
+++ b/backend/src/main/java/com/eaa/recruit/config/KafkaConfig.java
@@ -1,6 +1,8 @@
 package com.eaa.recruit.config;
 
 import com.eaa.recruit.messaging.KafkaTopics;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -83,5 +85,15 @@ public class KafkaConfig {
                 .partitions(3)
                 .replicas(1)
                 .build();
+    }
+
+    // FR-38: admin client for health monitoring
+    @Bean(destroyMethod = "close")
+    public AdminClient kafkaAdminClient() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 5000);
+        config.put(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 5000);
+        return AdminClient.create(config);
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/config/XaiProperties.java
+++ b/backend/src/main/java/com/eaa/recruit/config/XaiProperties.java
@@ -1,0 +1,14 @@
+package com.eaa.recruit.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "xai")
+public class XaiProperties {
+
+    private String reportsDir = "./xai-reports";
+
+    public String getReportsDir() { return reportsDir; }
+    public void setReportsDir(String reportsDir) { this.reportsDir = reportsDir; }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/AdminSystemController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AdminSystemController.java
@@ -1,0 +1,138 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.admin.AiModelRequest;
+import com.eaa.recruit.dto.admin.AiModelResponse;
+import com.eaa.recruit.dto.admin.AuditLogResponse;
+import com.eaa.recruit.dto.admin.SystemHealthResponse;
+import com.eaa.recruit.entity.AuditLog;
+import com.eaa.recruit.repository.AuditLogRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsAdmin;
+import com.eaa.recruit.security.rbac.IsSuperAdmin;
+import com.eaa.recruit.service.AiModelService;
+import com.eaa.recruit.service.ArchiveService;
+import com.eaa.recruit.service.SystemHealthService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * FR-36: Job archiving (recruiter+)
+ * FR-37: Audit log access (admin+)
+ * FR-38: System health (super admin)
+ * FR-39: AI model management (super admin)
+ */
+@RestController
+@RequestMapping("/api/v1/admin")
+public class AdminSystemController {
+
+    private final ArchiveService      archiveService;
+    private final AuditLogRepository  auditLogRepository;
+    private final SystemHealthService systemHealthService;
+    private final AiModelService      aiModelService;
+
+    public AdminSystemController(ArchiveService archiveService,
+                                  AuditLogRepository auditLogRepository,
+                                  SystemHealthService systemHealthService,
+                                  AiModelService aiModelService) {
+        this.archiveService      = archiveService;
+        this.auditLogRepository  = auditLogRepository;
+        this.systemHealthService = systemHealthService;
+        this.aiModelService      = aiModelService;
+    }
+
+    /** POST /api/v1/admin/jobs/{id}/archive — FR-36 */
+    @IsAdmin
+    @PostMapping("/jobs/{id}/archive")
+    public ResponseEntity<ApiResponse<Void>> archiveJob(
+            @PathVariable("id") Long jobId,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        archiveService.archive(jobId, principal);
+        return ResponseEntity.ok(ApiResponse.success("Job archived"));
+    }
+
+    /** GET /api/v1/admin/audit-logs — FR-37 */
+    @IsAdmin
+    @GetMapping("/audit-logs")
+    public ResponseEntity<ApiResponse<List<AuditLogResponse>>> getAuditLogs(
+            @PageableDefault(size = 20) Pageable pageable) {
+
+        Page<AuditLog> page = auditLogRepository.findAllByOrderByChangedAtDesc(pageable);
+        List<AuditLogResponse> responses = page.stream().map(this::toResponse).toList();
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /** GET /api/v1/admin/audit-logs/{entityType}/{entityId} — FR-37 */
+    @IsAdmin
+    @GetMapping("/audit-logs/{entityType}/{entityId}")
+    public ResponseEntity<ApiResponse<List<AuditLogResponse>>> getEntityAuditLogs(
+            @PathVariable String entityType,
+            @PathVariable Long entityId,
+            @PageableDefault(size = 20) Pageable pageable) {
+
+        Page<AuditLog> page = auditLogRepository.findByEntityTypeAndEntityIdOrderByChangedAtDesc(
+                entityType.toUpperCase(), entityId, pageable);
+        List<AuditLogResponse> responses = page.stream().map(this::toResponse).toList();
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /** GET /api/v1/admin/system/health — FR-38 */
+    @IsSuperAdmin
+    @GetMapping("/system/health")
+    public ResponseEntity<ApiResponse<SystemHealthResponse>> getSystemHealth() {
+        return ResponseEntity.ok(ApiResponse.success(systemHealthService.getHealth()));
+    }
+
+    /** POST /api/v1/admin/ai-models — FR-39 */
+    @IsSuperAdmin
+    @PostMapping("/ai-models")
+    public ResponseEntity<ApiResponse<AiModelResponse>> registerModel(
+            @Valid @RequestBody AiModelRequest request,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        AiModelResponse response = aiModelService.register(request, principal);
+        return ResponseEntity.ok(ApiResponse.success("AI model registered", response));
+    }
+
+    /** GET /api/v1/admin/ai-models — FR-39 */
+    @IsSuperAdmin
+    @GetMapping("/ai-models")
+    public ResponseEntity<ApiResponse<List<AiModelResponse>>> listModels() {
+        return ResponseEntity.ok(ApiResponse.success(aiModelService.listAll()));
+    }
+
+    /** GET /api/v1/admin/ai-models/active — FR-39 */
+    @IsSuperAdmin
+    @GetMapping("/ai-models/active")
+    public ResponseEntity<ApiResponse<AiModelResponse>> getActiveModel() {
+        return ResponseEntity.ok(ApiResponse.success(aiModelService.getActive()));
+    }
+
+    /** POST /api/v1/admin/ai-models/{id}/activate — FR-39 */
+    @IsSuperAdmin
+    @PostMapping("/ai-models/{id}/activate")
+    public ResponseEntity<ApiResponse<AiModelResponse>> activateModel(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.success("Model activated", aiModelService.activate(id)));
+    }
+
+    private AuditLogResponse toResponse(AuditLog log) {
+        return new AuditLogResponse(
+                log.getId(),
+                log.getEntityType(),
+                log.getEntityId(),
+                log.getOldStatus(),
+                log.getNewStatus(),
+                log.getChangedBy() != null ? log.getChangedBy().getId() : null,
+                log.getChangedBy() != null ? log.getChangedBy().getEmail() : null,
+                log.getChangedAt(),
+                log.getReason());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/AnalyticsController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AnalyticsController.java
@@ -1,0 +1,31 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.analytics.AnalyticsExportResponse;
+import com.eaa.recruit.security.rbac.IsSuperAdmin;
+import com.eaa.recruit.service.AnalyticsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * FR-40: Analytics export for super admin.
+ */
+@RestController
+@RequestMapping("/api/v1/analytics")
+public class AnalyticsController {
+
+    private final AnalyticsService analyticsService;
+
+    public AnalyticsController(AnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
+
+    /** GET /api/v1/analytics/export */
+    @IsSuperAdmin
+    @GetMapping("/export")
+    public ResponseEntity<ApiResponse<AnalyticsExportResponse>> export() {
+        return ResponseEntity.ok(ApiResponse.success(analyticsService.export()));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/FeedbackController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/FeedbackController.java
@@ -1,0 +1,79 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.application.DecisionRequest;
+import com.eaa.recruit.dto.application.DecisionResponse;
+import com.eaa.recruit.dto.application.FeedbackReportResponse;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsCandidate;
+import com.eaa.recruit.security.rbac.IsRecruiter;
+import com.eaa.recruit.service.FeedbackReportService;
+import com.eaa.recruit.service.FinalDecisionService;
+import com.eaa.recruit.service.XaiReportService;
+import jakarta.validation.Valid;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * FR-33: Final decision (recruiter).
+ * FR-34: Feedback report (candidate).
+ * FR-35: XAI PDF download (candidate).
+ */
+@RestController
+@RequestMapping("/api/v1/applications")
+public class FeedbackController {
+
+    private final FinalDecisionService   finalDecisionService;
+    private final FeedbackReportService  feedbackReportService;
+    private final XaiReportService       xaiReportService;
+
+    public FeedbackController(FinalDecisionService finalDecisionService,
+                               FeedbackReportService feedbackReportService,
+                               XaiReportService xaiReportService) {
+        this.finalDecisionService  = finalDecisionService;
+        this.feedbackReportService = feedbackReportService;
+        this.xaiReportService      = xaiReportService;
+    }
+
+    /** POST /api/v1/applications/{id}/decision — FR-33 */
+    @IsRecruiter
+    @PostMapping("/{id}/decision")
+    public ResponseEntity<ApiResponse<DecisionResponse>> recordDecision(
+            @PathVariable("id") Long applicationId,
+            @Valid @RequestBody DecisionRequest request,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        DecisionResponse response = finalDecisionService.recordDecision(applicationId, request, principal);
+        return ResponseEntity.ok(ApiResponse.success("Decision recorded", response));
+    }
+
+    /** GET /api/v1/applications/{id}/feedback — FR-34 */
+    @IsCandidate
+    @GetMapping("/{id}/feedback")
+    public ResponseEntity<ApiResponse<FeedbackReportResponse>> getFeedback(
+            @PathVariable("id") Long applicationId,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        FeedbackReportResponse response = feedbackReportService.getFeedback(applicationId, principal);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /** GET /api/v1/applications/{id}/xai-report — FR-35 */
+    @IsCandidate
+    @GetMapping("/{id}/xai-report")
+    public ResponseEntity<Resource> downloadXaiReport(
+            @PathVariable("id") Long applicationId,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        Resource resource = xaiReportService.getReport(applicationId, principal);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"xai-report-" + applicationId + ".pdf\"")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(resource);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/InternalController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/InternalController.java
@@ -3,6 +3,7 @@ package com.eaa.recruit.controller;
 import com.eaa.recruit.config.InternalApiKeyProperties;
 import com.eaa.recruit.dto.ApiResponse;
 import com.eaa.recruit.dto.application.AiScoreCallbackRequest;
+import com.eaa.recruit.dto.internal.ExamScoreCallbackRequest;
 import com.eaa.recruit.exception.UnauthorizedException;
 import com.eaa.recruit.service.ApplicationService;
 import jakarta.validation.Valid;
@@ -39,6 +40,21 @@ public class InternalController {
         validateApiKey(apiKey);
         applicationService.applyAiScore(applicationId, request);
         return ResponseEntity.ok(ApiResponse.success("AI score applied"));
+    }
+
+    /**
+     * POST /api/v1/internal/applications/{id}/exam-score
+     * FR-27: Receive exam score from Go engine.
+     */
+    @PostMapping("/applications/{id}/exam-score")
+    public ResponseEntity<ApiResponse<Void>> receiveExamScore(
+            @PathVariable("id") Long applicationId,
+            @RequestHeader("X-Internal-Api-Key") String apiKey,
+            @Valid @RequestBody ExamScoreCallbackRequest request) {
+
+        validateApiKey(apiKey);
+        applicationService.applyExamScore(applicationId, request);
+        return ResponseEntity.ok(ApiResponse.success("Exam score applied"));
     }
 
     private void validateApiKey(String provided) {

--- a/backend/src/main/java/com/eaa/recruit/controller/ShortlistController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/ShortlistController.java
@@ -1,0 +1,34 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.application.ShortlistRequest;
+import com.eaa.recruit.dto.application.ShortlistResponse;
+import com.eaa.recruit.security.rbac.IsRecruiter;
+import com.eaa.recruit.service.ShortlistService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * FR-29: Recruiter shortlists candidates.
+ */
+@RestController
+@RequestMapping("/api/v1/applications")
+public class ShortlistController {
+
+    private final ShortlistService shortlistService;
+
+    public ShortlistController(ShortlistService shortlistService) {
+        this.shortlistService = shortlistService;
+    }
+
+    /** POST /api/v1/applications/shortlist */
+    @IsRecruiter
+    @PostMapping("/shortlist")
+    public ResponseEntity<ApiResponse<ShortlistResponse>> shortlist(
+            @Valid @RequestBody ShortlistRequest request) {
+
+        ShortlistResponse response = shortlistService.shortlist(request);
+        return ResponseEntity.ok(ApiResponse.success("Shortlisting complete", response));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/controller/SlotBookingController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/SlotBookingController.java
@@ -1,0 +1,38 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.application.SlotBookingRequest;
+import com.eaa.recruit.repository.AvailabilitySlotRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsCandidate;
+import com.eaa.recruit.service.SlotBookingService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * FR-30/31: Candidate books an interview slot.
+ */
+@RestController
+@RequestMapping("/api/v1/applications")
+public class SlotBookingController {
+
+    private final SlotBookingService slotBookingService;
+
+    public SlotBookingController(SlotBookingService slotBookingService) {
+        this.slotBookingService = slotBookingService;
+    }
+
+    /** POST /api/v1/applications/{id}/book-slot */
+    @IsCandidate
+    @PostMapping("/{id}/book-slot")
+    public ResponseEntity<ApiResponse<Void>> bookSlot(
+            @PathVariable("id") Long applicationId,
+            @Valid @RequestBody SlotBookingRequest request,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        slotBookingService.bookSlot(applicationId, request, principal);
+        return ResponseEntity.ok(ApiResponse.success("Interview slot booked"));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/AiModelRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/AiModelRequest.java
@@ -1,0 +1,11 @@
+package com.eaa.recruit.dto.admin;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AiModelRequest(
+
+        @NotBlank(message = "modelVersion is required")
+        String modelVersion,
+
+        String description
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/AiModelResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/AiModelResponse.java
@@ -1,0 +1,12 @@
+package com.eaa.recruit.dto.admin;
+
+import java.time.Instant;
+
+public record AiModelResponse(
+        Long id,
+        String modelVersion,
+        String description,
+        boolean active,
+        Instant activatedAt,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/AuditLogResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/AuditLogResponse.java
@@ -1,0 +1,15 @@
+package com.eaa.recruit.dto.admin;
+
+import java.time.Instant;
+
+public record AuditLogResponse(
+        Long id,
+        String entityType,
+        Long entityId,
+        String oldStatus,
+        String newStatus,
+        Long changedById,
+        String changedByEmail,
+        Instant changedAt,
+        String reason
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/SystemHealthResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/SystemHealthResponse.java
@@ -1,0 +1,15 @@
+package com.eaa.recruit.dto.admin;
+
+public record SystemHealthResponse(
+        DatabaseHealth database,
+        RedisHealth redis,
+        KafkaHealth kafka,
+        long uptimeSeconds
+) {
+
+    public record DatabaseHealth(boolean up, int activeConnections, int idleConnections) {}
+
+    public record RedisHealth(boolean up, String info) {}
+
+    public record KafkaHealth(boolean up, String details) {}
+}

--- a/backend/src/main/java/com/eaa/recruit/dto/analytics/AnalyticsExportResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/analytics/AnalyticsExportResponse.java
@@ -1,0 +1,17 @@
+package com.eaa.recruit.dto.analytics;
+
+import java.util.List;
+
+public record AnalyticsExportResponse(
+        List<JobAnalytics> jobs
+) {
+
+    public record JobAnalytics(
+            String jobTitle,
+            long total,
+            double avgScore,
+            long selected,
+            long rejected,
+            long waitlisted
+    ) {}
+}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/DecisionRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/DecisionRequest.java
@@ -1,0 +1,12 @@
+package com.eaa.recruit.dto.application;
+
+import com.eaa.recruit.entity.ApplicationStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record DecisionRequest(
+
+        @NotNull(message = "decision is required")
+        ApplicationStatus decision,
+
+        String notes
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/DecisionResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/DecisionResponse.java
@@ -1,0 +1,12 @@
+package com.eaa.recruit.dto.application;
+
+import com.eaa.recruit.entity.ApplicationStatus;
+
+import java.time.Instant;
+
+public record DecisionResponse(
+        Long applicationId,
+        ApplicationStatus status,
+        String notes,
+        Instant decidedAt
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/FeedbackReportResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/FeedbackReportResponse.java
@@ -1,0 +1,15 @@
+package com.eaa.recruit.dto.application;
+
+import com.eaa.recruit.entity.ApplicationStatus;
+
+public record FeedbackReportResponse(
+        Long applicationId,
+        String jobTitle,
+        ApplicationStatus status,
+        Double cvRelevanceScore,
+        Double examScore,
+        Boolean hardFilterPassed,
+        Double finalScore,
+        String xaiReportUrl,
+        String decisionNotes
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/ShortlistRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/ShortlistRequest.java
@@ -1,0 +1,11 @@
+package com.eaa.recruit.dto.application;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record ShortlistRequest(
+
+        @NotEmpty(message = "applicationIds must not be empty")
+        List<Long> applicationIds
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/ShortlistResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/ShortlistResponse.java
@@ -1,0 +1,6 @@
+package com.eaa.recruit.dto.application;
+
+public record ShortlistResponse(
+        int shortlisted,
+        int skipped
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/SlotBookingRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/SlotBookingRequest.java
@@ -1,0 +1,9 @@
+package com.eaa.recruit.dto.application;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SlotBookingRequest(
+
+        @NotNull(message = "slotId is required")
+        Long slotId
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/internal/ExamScoreCallbackRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/internal/ExamScoreCallbackRequest.java
@@ -1,0 +1,13 @@
+package com.eaa.recruit.dto.internal;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+public record ExamScoreCallbackRequest(
+
+        @NotNull(message = "examScore is required")
+        @DecimalMin(value = "0.0", message = "examScore must be >= 0")
+        @DecimalMax(value = "100.0", message = "examScore must be <= 100")
+        Double examScore
+) {}

--- a/backend/src/main/java/com/eaa/recruit/entity/AiModelVersion.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/AiModelVersion.java
@@ -1,0 +1,63 @@
+package com.eaa.recruit.entity;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "ai_model_versions",
+    indexes = {
+        @Index(name = "idx_ai_model_active", columnList = "is_active")
+    }
+)
+public class AiModelVersion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "model_version", nullable = false, length = 100)
+    private String modelVersion;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "activated_at", nullable = false)
+    private Instant activatedAt;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_id")
+    private User createdBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected AiModelVersion() {}
+
+    private AiModelVersion(String modelVersion, String description, User createdBy) {
+        this.modelVersion = modelVersion;
+        this.description  = description;
+        this.createdBy    = createdBy;
+        this.activatedAt  = Instant.now();
+        this.createdAt    = Instant.now();
+    }
+
+    public static AiModelVersion create(String modelVersion, String description, User createdBy) {
+        return new AiModelVersion(modelVersion, description, createdBy);
+    }
+
+    public Long    getId()           { return id; }
+    public String  getModelVersion() { return modelVersion; }
+    public String  getDescription()  { return description; }
+    public Instant getActivatedAt()  { return activatedAt; }
+    public boolean isActive()        { return active; }
+    public User    getCreatedBy()    { return createdBy; }
+    public Instant getCreatedAt()    { return createdAt; }
+
+    public void activate()   { this.active = true;  this.activatedAt = Instant.now(); }
+    public void deactivate() { this.active = false; }
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/Application.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/Application.java
@@ -3,6 +3,7 @@ package com.eaa.recruit.entity;
 import jakarta.persistence.*;
 
 import java.time.Instant;
+import java.util.Set;
 
 @Entity
 @Table(
@@ -14,10 +15,15 @@ import java.time.Instant;
     indexes = {
         @Index(name = "idx_applications_candidate", columnList = "candidate_id"),
         @Index(name = "idx_applications_job",       columnList = "job_id"),
-        @Index(name = "idx_applications_status",    columnList = "status")
+        @Index(name = "idx_applications_status",    columnList = "status"),
+        @Index(name = "idx_applications_slot",      columnList = "interview_slot_id")
     }
 )
 public class Application extends BaseEntity {
+
+    private static final Set<ApplicationStatus> FINAL_STATUSES =
+            Set.of(ApplicationStatus.SELECTED, ApplicationStatus.REJECTED,
+                   ApplicationStatus.WAITLISTED, ApplicationStatus.HARD_FILTER_FAILED);
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "candidate_id", nullable = false, updatable = false)
@@ -55,6 +61,23 @@ public class Application extends BaseEntity {
     @Column(name = "submitted_at", nullable = false, updatable = false)
     private Instant submittedAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_slot_id")
+    private AvailabilitySlot interviewSlot;
+
+    @Column(name = "reminder_sent", nullable = false)
+    private boolean reminderSent = false;
+
+    @Column(name = "decision_notes", columnDefinition = "TEXT")
+    private String decisionNotes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "decision_by_id")
+    private User decisionBy;
+
+    @Column(name = "decided_at")
+    private Instant decidedAt;
+
     protected Application() {}
 
     private Application(User candidate, JobPosting job, String cvFilePath) {
@@ -71,17 +94,26 @@ public class Application extends BaseEntity {
 
     // ── Getters ──────────────────────────────────────────────────────────────
 
-    public User           getCandidate()          { return candidate; }
-    public JobPosting     getJob()                { return job; }
-    public String         getCvFilePath()         { return cvFilePath; }
-    public Double         getCvRelevanceScore()   { return cvRelevanceScore; }
-    public Double         getExamScore()          { return examScore; }
-    public Boolean        getHardFilterPassed()   { return hardFilterPassed; }
-    public Double         getFinalScore()         { return finalScore; }
-    public ApplicationStatus getStatus()          { return status; }
-    public String         getXaiReportUrl()       { return xaiReportUrl; }
-    public String         getExamToken()          { return examToken; }
-    public Instant        getSubmittedAt()        { return submittedAt; }
+    public User              getCandidate()        { return candidate; }
+    public JobPosting        getJob()              { return job; }
+    public String            getCvFilePath()       { return cvFilePath; }
+    public Double            getCvRelevanceScore() { return cvRelevanceScore; }
+    public Double            getExamScore()        { return examScore; }
+    public Boolean           getHardFilterPassed() { return hardFilterPassed; }
+    public Double            getFinalScore()       { return finalScore; }
+    public ApplicationStatus getStatus()           { return status; }
+    public String            getXaiReportUrl()     { return xaiReportUrl; }
+    public String            getExamToken()        { return examToken; }
+    public Instant           getSubmittedAt()      { return submittedAt; }
+    public AvailabilitySlot  getInterviewSlot()    { return interviewSlot; }
+    public boolean           isReminderSent()      { return reminderSent; }
+    public String            getDecisionNotes()    { return decisionNotes; }
+    public User              getDecisionBy()       { return decisionBy; }
+    public Instant           getDecidedAt()        { return decidedAt; }
+
+    public boolean hasFinalDecision() {
+        return FINAL_STATUSES.contains(status);
+    }
 
     // ── State transitions ─────────────────────────────────────────────────────
 
@@ -103,5 +135,35 @@ public class Application extends BaseEntity {
     public void authorizeExam(String token) {
         this.examToken = token;
         this.status    = ApplicationStatus.EXAM_AUTHORIZED;
+    }
+
+    public void recordExamScore(double score, double computedFinalScore) {
+        this.examScore  = score;
+        this.finalScore = computedFinalScore;
+        this.status     = ApplicationStatus.EXAM_COMPLETED;
+    }
+
+    public void shortlist() {
+        this.status = ApplicationStatus.SHORTLISTED;
+    }
+
+    public void bookInterviewSlot(AvailabilitySlot slot) {
+        this.interviewSlot = slot;
+        this.status        = ApplicationStatus.INTERVIEW_SCHEDULED;
+    }
+
+    public void recordDecision(ApplicationStatus decision, String notes, User by) {
+        this.status        = decision;
+        this.decisionNotes = notes;
+        this.decisionBy    = by;
+        this.decidedAt     = Instant.now();
+    }
+
+    public void markReminderSent() {
+        this.reminderSent = true;
+    }
+
+    public void updateFinalScore(double score) {
+        this.finalScore = score;
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/entity/AuditLog.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/AuditLog.java
@@ -1,0 +1,69 @@
+package com.eaa.recruit.entity;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "audit_logs",
+    indexes = {
+        @Index(name = "idx_audit_entity", columnList = "entity_type, entity_id"),
+        @Index(name = "idx_audit_changed_at", columnList = "changed_at")
+    }
+)
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "entity_type", nullable = false, length = 50)
+    private String entityType;
+
+    @Column(name = "entity_id", nullable = false)
+    private Long entityId;
+
+    @Column(name = "old_status", length = 50)
+    private String oldStatus;
+
+    @Column(name = "new_status", nullable = false, length = 50)
+    private String newStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "changed_by")
+    private User changedBy;
+
+    @Column(name = "changed_at", nullable = false)
+    private Instant changedAt;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    protected AuditLog() {}
+
+    private AuditLog(String entityType, Long entityId, String oldStatus,
+                     String newStatus, User changedBy, String reason) {
+        this.entityType = entityType;
+        this.entityId   = entityId;
+        this.oldStatus  = oldStatus;
+        this.newStatus  = newStatus;
+        this.changedBy  = changedBy;
+        this.reason     = reason;
+        this.changedAt  = Instant.now();
+    }
+
+    public static AuditLog of(String entityType, Long entityId, String oldStatus,
+                               String newStatus, User changedBy, String reason) {
+        return new AuditLog(entityType, entityId, oldStatus, newStatus, changedBy, reason);
+    }
+
+    public Long    getId()         { return id; }
+    public String  getEntityType() { return entityType; }
+    public Long    getEntityId()   { return entityId; }
+    public String  getOldStatus()  { return oldStatus; }
+    public String  getNewStatus()  { return newStatus; }
+    public User    getChangedBy()  { return changedBy; }
+    public Instant getChangedAt()  { return changedAt; }
+    public String  getReason()     { return reason; }
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/AvailabilitySlot.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/AvailabilitySlot.java
@@ -31,6 +31,13 @@ public class AvailabilitySlot extends BaseEntity {
     @Column(name = "is_booked", nullable = false)
     private boolean booked = false;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booked_by_id")
+    private User bookedBy;
+
+    @Column(name = "booked_at")
+    private java.time.Instant bookedAt;
+
     protected AvailabilitySlot() {}
 
     private AvailabilitySlot(User recruiter, LocalDate slotDate,
@@ -51,6 +58,12 @@ public class AvailabilitySlot extends BaseEntity {
     public LocalTime getStartTime() { return startTime; }
     public LocalTime getEndTime()   { return endTime; }
     public boolean   isBooked()     { return booked; }
+    public User      getBookedBy()  { return bookedBy; }
+    public java.time.Instant getBookedAt() { return bookedAt; }
 
-    public void book() { this.booked = true; }
+    public void book(User candidate) {
+        this.booked    = true;
+        this.bookedBy  = candidate;
+        this.bookedAt  = java.time.Instant.now();
+    }
 }

--- a/backend/src/main/java/com/eaa/recruit/entity/JobPosting.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/JobPosting.java
@@ -86,4 +86,5 @@ public class JobPosting extends BaseEntity {
     public void publish()               { this.status = JobPostingStatus.OPEN; }
     public void close()                 { this.status = JobPostingStatus.CLOSED; }
     public void scheduleExam()          { this.status = JobPostingStatus.EXAM_SCHEDULED; }
+    public void archive()               { this.status = JobPostingStatus.ARCHIVED; }
 }

--- a/backend/src/main/java/com/eaa/recruit/entity/JobPostingStatus.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/JobPostingStatus.java
@@ -4,5 +4,6 @@ public enum JobPostingStatus {
     DRAFT,
     OPEN,
     CLOSED,
-    EXAM_SCHEDULED
+    EXAM_SCHEDULED,
+    ARCHIVED
 }

--- a/backend/src/main/java/com/eaa/recruit/notification/CandidateNotificationPort.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/CandidateNotificationPort.java
@@ -5,4 +5,11 @@ public interface CandidateNotificationPort {
     void notifyHardFilterFailed(String email, String fullName, String jobTitle);
 
     void notifyExamAuthorized(String email, String fullName, String jobTitle, String examToken);
+
+    void notifyShortlisted(String email, String fullName, String jobTitle);
+
+    void notifyDecision(String email, String fullName, String jobTitle, String decision, String notes);
+
+    void notifyInterviewReminder(String email, String fullName, String jobTitle,
+                                  String slotDate, String startTime);
 }

--- a/backend/src/main/java/com/eaa/recruit/notification/MockCandidateNotificationAdapter.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/MockCandidateNotificationAdapter.java
@@ -20,4 +20,24 @@ public class MockCandidateNotificationAdapter implements CandidateNotificationPo
         log.info("[MOCK NOTIFY] Exam authorized — to='{}' name='{}' job='{}' token='{}'",
                 email, fullName, jobTitle, examToken);
     }
+
+    @Override
+    public void notifyShortlisted(String email, String fullName, String jobTitle) {
+        log.info("[MOCK NOTIFY] Shortlisted — to='{}' name='{}' job='{}'",
+                email, fullName, jobTitle);
+    }
+
+    @Override
+    public void notifyDecision(String email, String fullName, String jobTitle,
+                                String decision, String notes) {
+        log.info("[MOCK NOTIFY] Decision='{}' — to='{}' name='{}' job='{}' notes='{}'",
+                decision, email, fullName, jobTitle, notes);
+    }
+
+    @Override
+    public void notifyInterviewReminder(String email, String fullName, String jobTitle,
+                                         String slotDate, String startTime) {
+        log.info("[MOCK NOTIFY] Interview reminder — to='{}' name='{}' job='{}' date='{}' time='{}'",
+                email, fullName, jobTitle, slotDate, startTime);
+    }
 }

--- a/backend/src/main/java/com/eaa/recruit/repository/AiModelVersionRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/AiModelVersionRepository.java
@@ -1,0 +1,19 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.AiModelVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface AiModelVersionRepository extends JpaRepository<AiModelVersion, Long> {
+
+    Optional<AiModelVersion> findByActiveTrue();
+
+    boolean existsByModelVersion(String modelVersion);
+
+    @Modifying
+    @Query("UPDATE AiModelVersion v SET v.active = false WHERE v.active = true")
+    void deactivateAll();
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
@@ -37,4 +38,28 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
            nativeQuery = true)
     Page<DashboardProjection> findDashboardByRecruiterId(
             @Param("recruiterId") Long recruiterId, Pageable pageable);
+
+    // FR-32: fetch candidates with upcoming interviews where reminder not yet sent
+    @Query("""
+            SELECT a FROM Application a
+            WHERE a.status = com.eaa.recruit.entity.ApplicationStatus.INTERVIEW_SCHEDULED
+              AND a.reminderSent = false
+              AND a.interviewSlot.slotDate = :date
+            """)
+    List<Application> findScheduledForDateWithoutReminder(@Param("date") LocalDate date);
+
+    // FR-40: analytics
+    @Query(value = """
+            SELECT jp.title          AS jobTitle,
+                   COUNT(a.id)       AS total,
+                   AVG(a.final_score) AS avgScore,
+                   SUM(CASE WHEN a.status = 'SELECTED'   THEN 1 ELSE 0 END) AS selected,
+                   SUM(CASE WHEN a.status = 'REJECTED'   THEN 1 ELSE 0 END) AS rejected,
+                   SUM(CASE WHEN a.status = 'WAITLISTED' THEN 1 ELSE 0 END) AS waitlisted
+            FROM applications a
+            JOIN job_postings jp ON jp.id = a.job_id
+            GROUP BY jp.id, jp.title
+            ORDER BY jp.title
+            """, nativeQuery = true)
+    List<Object[]> findAnalyticsSummary();
 }

--- a/backend/src/main/java/com/eaa/recruit/repository/AuditLogRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/AuditLogRepository.java
@@ -1,0 +1,14 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.AuditLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+
+    Page<AuditLog> findByEntityTypeAndEntityIdOrderByChangedAtDesc(
+            String entityType, Long entityId, Pageable pageable);
+
+    Page<AuditLog> findAllByOrderByChangedAtDesc(Pageable pageable);
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/AvailabilitySlotRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/AvailabilitySlotRepository.java
@@ -25,4 +25,13 @@ public interface AvailabilitySlotRepository extends JpaRepository<AvailabilitySl
                           @Param("slotDate")    LocalDate slotDate,
                           @Param("startTime")   LocalTime startTime,
                           @Param("endTime")     LocalTime endTime);
+
+    // FR-30: available slots for a job's exam date range
+    @Query("""
+            SELECT s FROM AvailabilitySlot s
+            WHERE s.booked = false
+              AND s.slotDate >= :fromDate
+            ORDER BY s.slotDate ASC, s.startTime ASC
+            """)
+    List<AvailabilitySlot> findAvailableSlots(@Param("fromDate") LocalDate fromDate);
 }

--- a/backend/src/main/java/com/eaa/recruit/scheduler/InterviewReminderScheduler.java
+++ b/backend/src/main/java/com/eaa/recruit/scheduler/InterviewReminderScheduler.java
@@ -1,0 +1,68 @@
+package com.eaa.recruit.scheduler;
+
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * FR-32: Send interview reminder N days before the scheduled slot.
+ * Runs daily at 08:00 by default. Idempotent — reminderSent flag prevents duplicates.
+ */
+@Component
+public class InterviewReminderScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(InterviewReminderScheduler.class);
+
+    @Value("${scheduler.interview-reminder.days-before:1}")
+    private int daysBefore;
+
+    private final ApplicationRepository     applicationRepository;
+    private final CandidateNotificationPort candidateNotificationPort;
+
+    public InterviewReminderScheduler(ApplicationRepository applicationRepository,
+                                       CandidateNotificationPort candidateNotificationPort) {
+        this.applicationRepository     = applicationRepository;
+        this.candidateNotificationPort = candidateNotificationPort;
+    }
+
+    @Scheduled(cron = "${scheduler.interview-reminder.cron:0 0 8 * * *}")
+    @Transactional
+    public void sendReminders() {
+        LocalDate targetDate = LocalDate.now().plusDays(daysBefore);
+
+        List<Application> upcoming = applicationRepository
+                .findScheduledForDateWithoutReminder(targetDate);
+
+        if (upcoming.isEmpty()) return;
+
+        for (Application application : upcoming) {
+            try {
+                candidateNotificationPort.notifyInterviewReminder(
+                        application.getCandidate().getEmail(),
+                        application.getCandidate().getFullName(),
+                        application.getJob().getTitle(),
+                        application.getInterviewSlot().getSlotDate().toString(),
+                        application.getInterviewSlot().getStartTime().toString());
+
+                application.markReminderSent();
+                applicationRepository.save(application);
+
+                log.info("Reminder sent applicationId={}", application.getId());
+            } catch (Exception e) {
+                log.error("Failed to send reminder for applicationId={}: {}",
+                        application.getId(), e.getMessage(), e);
+            }
+        }
+
+        log.info("Interview reminders sent for {} application(s)", upcoming.size());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/AiModelService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/AiModelService.java
@@ -1,0 +1,86 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.admin.AiModelRequest;
+import com.eaa.recruit.dto.admin.AiModelResponse;
+import com.eaa.recruit.entity.AiModelVersion;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.AiModelVersionRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * FR-39: Super admin manages AI model version registry.
+ */
+@Service
+public class AiModelService {
+
+    private final AiModelVersionRepository aiModelVersionRepository;
+    private final UserRepository            userRepository;
+
+    public AiModelService(AiModelVersionRepository aiModelVersionRepository,
+                           UserRepository userRepository) {
+        this.aiModelVersionRepository = aiModelVersionRepository;
+        this.userRepository           = userRepository;
+    }
+
+    @Transactional
+    public AiModelResponse register(AiModelRequest request, AuthenticatedUser principal) {
+        if (aiModelVersionRepository.existsByModelVersion(request.modelVersion())) {
+            throw new ConflictException("Model version already registered: " + request.modelVersion());
+        }
+
+        User creator = userRepository.findById(principal.id())
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        AiModelVersion model = AiModelVersion.create(request.modelVersion(), request.description(), creator);
+        model = aiModelVersionRepository.save(model);
+        return toResponse(model);
+    }
+
+    @Transactional
+    public AiModelResponse activate(Long modelId) {
+        AiModelVersion model = aiModelVersionRepository.findById(modelId)
+                .orElseThrow(() -> new ResourceNotFoundException("Model not found: " + modelId));
+
+        if (model.isActive()) {
+            throw new BusinessException("Model is already active");
+        }
+
+        // Deactivate current active model, then activate new one
+        aiModelVersionRepository.deactivateAll();
+        model.activate();
+        aiModelVersionRepository.save(model);
+        return toResponse(model);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AiModelResponse> listAll() {
+        return aiModelVersionRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AiModelResponse getActive() {
+        return aiModelVersionRepository.findByActiveTrue()
+                .map(this::toResponse)
+                .orElseThrow(() -> new ResourceNotFoundException("No active AI model version found"));
+    }
+
+    private AiModelResponse toResponse(AiModelVersion m) {
+        return new AiModelResponse(
+                m.getId(),
+                m.getModelVersion(),
+                m.getDescription(),
+                m.isActive(),
+                m.getActivatedAt(),
+                m.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/AnalyticsService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/AnalyticsService.java
@@ -1,0 +1,48 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.analytics.AnalyticsExportResponse;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * FR-40: Analytics export for super admin.
+ */
+@Service
+public class AnalyticsService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public AnalyticsService(ApplicationRepository applicationRepository) {
+        this.applicationRepository = applicationRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public AnalyticsExportResponse export() {
+        List<Object[]> rows = applicationRepository.findAnalyticsSummary();
+        List<AnalyticsExportResponse.JobAnalytics> jobs = rows.stream()
+                .map(r -> new AnalyticsExportResponse.JobAnalytics(
+                        (String) r[0],
+                        toLong(r[1]),
+                        toDouble(r[2]),
+                        toLong(r[3]),
+                        toLong(r[4]),
+                        toLong(r[5])))
+                .toList();
+        return new AnalyticsExportResponse(jobs);
+    }
+
+    private long toLong(Object o) {
+        if (o == null) return 0L;
+        if (o instanceof Number n) return n.longValue();
+        return Long.parseLong(o.toString());
+    }
+
+    private double toDouble(Object o) {
+        if (o == null) return 0.0;
+        if (o instanceof Number n) return n.doubleValue();
+        return Double.parseDouble(o.toString());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
@@ -2,7 +2,9 @@ package com.eaa.recruit.service;
 
 import com.eaa.recruit.dto.application.AiScoreCallbackRequest;
 import com.eaa.recruit.dto.application.SubmitApplicationResponse;
+import com.eaa.recruit.dto.internal.ExamScoreCallbackRequest;
 import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.ApplicationStatus;
 import com.eaa.recruit.entity.JobPosting;
 import com.eaa.recruit.entity.JobPostingStatus;
 import com.eaa.recruit.entity.User;
@@ -32,19 +34,22 @@ public class ApplicationService {
     private final FileStorageService     fileStorageService;
     private final KafkaEventPublisher    kafkaEventPublisher;
     private final HardFilterService      hardFilterService;
+    private final WeightedScoringService weightedScoringService;
 
     public ApplicationService(ApplicationRepository applicationRepository,
                                JobPostingRepository jobPostingRepository,
                                UserRepository userRepository,
                                FileStorageService fileStorageService,
                                KafkaEventPublisher kafkaEventPublisher,
-                               HardFilterService hardFilterService) {
+                               HardFilterService hardFilterService,
+                               WeightedScoringService weightedScoringService) {
         this.applicationRepository = applicationRepository;
         this.jobPostingRepository  = jobPostingRepository;
         this.userRepository        = userRepository;
         this.fileStorageService    = fileStorageService;
         this.kafkaEventPublisher   = kafkaEventPublisher;
         this.hardFilterService     = hardFilterService;
+        this.weightedScoringService = weightedScoringService;
     }
 
     /** FR-19: Submit application with CV upload. */
@@ -103,5 +108,23 @@ public class ApplicationService {
 
         // FR-22: immediately run hard filter after AI score is recorded
         hardFilterService.applyHardFilter(application);
+    }
+
+    /** FR-27: Receive exam score from Go engine, recompute weighted final score. */
+    @Transactional
+    public void applyExamScore(Long applicationId, ExamScoreCallbackRequest request) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
+
+        if (application.getStatus() != ApplicationStatus.EXAM_AUTHORIZED) {
+            throw new BusinessException("Exam score can only be applied to EXAM_AUTHORIZED applications");
+        }
+
+        double finalScore = weightedScoringService.compute(application);
+        application.recordExamScore(request.examScore(), finalScore);
+        applicationRepository.save(application);
+
+        log.info("Exam score applied applicationId={} examScore={} finalScore={}",
+                applicationId, request.examScore(), finalScore);
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/service/ArchiveService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ArchiveService.java
@@ -1,0 +1,62 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.JobPostingStatus;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.JobPostingRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+/**
+ * FR-36: Archive closed/exam-scheduled jobs.
+ */
+@Service
+public class ArchiveService {
+
+    private static final Logger log = LoggerFactory.getLogger(ArchiveService.class);
+
+    private static final Set<JobPostingStatus> ARCHIVABLE =
+            Set.of(JobPostingStatus.CLOSED, JobPostingStatus.EXAM_SCHEDULED);
+
+    private final JobPostingRepository jobPostingRepository;
+    private final UserRepository       userRepository;
+    private final AuditLogService      auditLogService;
+
+    public ArchiveService(JobPostingRepository jobPostingRepository,
+                           UserRepository userRepository,
+                           AuditLogService auditLogService) {
+        this.jobPostingRepository = jobPostingRepository;
+        this.userRepository       = userRepository;
+        this.auditLogService      = auditLogService;
+    }
+
+    @Transactional
+    public void archive(Long jobId, AuthenticatedUser principal) {
+        JobPosting job = jobPostingRepository.findById(jobId)
+                .orElseThrow(() -> new ResourceNotFoundException("Job not found: " + jobId));
+
+        if (!ARCHIVABLE.contains(job.getStatus())) {
+            throw new BusinessException("Only CLOSED or EXAM_SCHEDULED jobs can be archived");
+        }
+
+        User actor = userRepository.findById(principal.id())
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        String oldStatus = job.getStatus().name();
+        job.archive();
+        jobPostingRepository.save(job);
+
+        auditLogService.log("JOB_POSTING", jobId, oldStatus,
+                JobPostingStatus.ARCHIVED.name(), actor, null);
+
+        log.info("Job archived id={} by={}", jobId, principal.id());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/AuditLogService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/AuditLogService.java
@@ -1,0 +1,27 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.entity.AuditLog;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.repository.AuditLogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * FR-37: Centralized audit logging for status changes.
+ */
+@Service
+public class AuditLogService {
+
+    private final AuditLogRepository auditLogRepository;
+
+    public AuditLogService(AuditLogRepository auditLogRepository) {
+        this.auditLogRepository = auditLogRepository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void log(String entityType, Long entityId, String oldStatus,
+                     String newStatus, User changedBy, String reason) {
+        auditLogRepository.save(AuditLog.of(entityType, entityId, oldStatus, newStatus, changedBy, reason));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/ExamService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ExamService.java
@@ -177,9 +177,14 @@ public class ExamService {
                 .filter(id -> id != null)
                 .toList();
 
+        // Use the job's exam date as the scheduled start time (FR-26)
+        Instant scheduledAt = exam.getJob().getExamDate()
+                .atStartOfDay(java.time.ZoneOffset.UTC)
+                .toInstant();
+
         ExamBatchReadyEvent event = ExamBatchReadyEvent.of(
                 exam.getId(), jobId, candidateIds,
-                exam.getDurationMinutes(), Instant.now());
+                exam.getDurationMinutes(), scheduledAt);
 
         try {
             kafkaEventPublisher.publishExamBatchReady(event);

--- a/backend/src/main/java/com/eaa/recruit/service/FeedbackReportService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/FeedbackReportService.java
@@ -1,0 +1,48 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.FeedbackReportResponse;
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * FR-34: Candidate views their feedback report.
+ */
+@Service
+public class FeedbackReportService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public FeedbackReportService(ApplicationRepository applicationRepository) {
+        this.applicationRepository = applicationRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public FeedbackReportResponse getFeedback(Long applicationId, AuthenticatedUser principal) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
+
+        if (!application.getCandidate().getId().equals(principal.id())) {
+            throw new BusinessException("You can only view feedback for your own applications");
+        }
+
+        if (!application.hasFinalDecision()) {
+            throw new BusinessException("Feedback not available until a final decision is made");
+        }
+
+        return new FeedbackReportResponse(
+                application.getId(),
+                application.getJob().getTitle(),
+                application.getStatus(),
+                application.getCvRelevanceScore(),
+                application.getExamScore(),
+                application.getHardFilterPassed(),
+                application.getFinalScore(),
+                application.getXaiReportUrl(),
+                application.getDecisionNotes());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/FinalDecisionService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/FinalDecisionService.java
@@ -1,0 +1,95 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.DecisionRequest;
+import com.eaa.recruit.dto.application.DecisionResponse;
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.ApplicationStatus;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+/**
+ * FR-33: Recruiter records final decision (SELECTED/REJECTED/WAITLISTED).
+ */
+@Service
+public class FinalDecisionService {
+
+    private static final Logger log = LoggerFactory.getLogger(FinalDecisionService.class);
+
+    private static final Set<ApplicationStatus> ALLOWED_DECISIONS =
+            Set.of(ApplicationStatus.SELECTED, ApplicationStatus.REJECTED,
+                   ApplicationStatus.WAITLISTED);
+
+    private static final Set<ApplicationStatus> ELIGIBLE_STATUSES =
+            Set.of(ApplicationStatus.INTERVIEW_SCHEDULED, ApplicationStatus.SHORTLISTED);
+
+    private final ApplicationRepository     applicationRepository;
+    private final UserRepository            userRepository;
+    private final CandidateNotificationPort candidateNotificationPort;
+    private final AuditLogService           auditLogService;
+
+    public FinalDecisionService(ApplicationRepository applicationRepository,
+                                 UserRepository userRepository,
+                                 CandidateNotificationPort candidateNotificationPort,
+                                 AuditLogService auditLogService) {
+        this.applicationRepository     = applicationRepository;
+        this.userRepository            = userRepository;
+        this.candidateNotificationPort = candidateNotificationPort;
+        this.auditLogService           = auditLogService;
+    }
+
+    @Transactional
+    public DecisionResponse recordDecision(Long applicationId, DecisionRequest request,
+                                            AuthenticatedUser principal) {
+        if (!ALLOWED_DECISIONS.contains(request.decision())) {
+            throw new BusinessException("Decision must be SELECTED, REJECTED, or WAITLISTED");
+        }
+
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
+
+        if (!ELIGIBLE_STATUSES.contains(application.getStatus())) {
+            throw new BusinessException("Final decision only allowed from SHORTLISTED or INTERVIEW_SCHEDULED status");
+        }
+
+        if (application.hasFinalDecision()) {
+            throw new BusinessException("Decision already recorded");
+        }
+
+        User recruiter = userRepository.findById(principal.id())
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        String oldStatus = application.getStatus().name();
+        application.recordDecision(request.decision(), request.notes(), recruiter);
+        applicationRepository.save(application);
+
+        auditLogService.log("APPLICATION", applicationId, oldStatus,
+                request.decision().name(), recruiter, request.notes());
+
+        candidateNotificationPort.notifyDecision(
+                application.getCandidate().getEmail(),
+                application.getCandidate().getFullName(),
+                application.getJob().getTitle(),
+                request.decision().name(),
+                request.notes());
+
+        log.info("Decision recorded applicationId={} decision={} by={}",
+                applicationId, request.decision(), principal.id());
+
+        return new DecisionResponse(
+                applicationId,
+                application.getStatus(),
+                application.getDecisionNotes(),
+                application.getDecidedAt());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/ShortlistService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ShortlistService.java
@@ -1,0 +1,60 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.ShortlistRequest;
+import com.eaa.recruit.dto.application.ShortlistResponse;
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.ApplicationStatus;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * FR-29: Recruiter shortlists candidates from EXAM_COMPLETED pool.
+ */
+@Service
+public class ShortlistService {
+
+    private static final Logger log = LoggerFactory.getLogger(ShortlistService.class);
+
+    private final ApplicationRepository     applicationRepository;
+    private final CandidateNotificationPort candidateNotificationPort;
+
+    public ShortlistService(ApplicationRepository applicationRepository,
+                             CandidateNotificationPort candidateNotificationPort) {
+        this.applicationRepository     = applicationRepository;
+        this.candidateNotificationPort = candidateNotificationPort;
+    }
+
+    @Transactional
+    public ShortlistResponse shortlist(ShortlistRequest request) {
+        int shortlisted = 0;
+        int skipped     = 0;
+
+        for (Long id : request.applicationIds()) {
+            Application application = applicationRepository.findById(id)
+                    .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + id));
+
+            if (application.getStatus() != ApplicationStatus.EXAM_COMPLETED) {
+                skipped++;
+                continue;
+            }
+
+            application.shortlist();
+            applicationRepository.save(application);
+
+            candidateNotificationPort.notifyShortlisted(
+                    application.getCandidate().getEmail(),
+                    application.getCandidate().getFullName(),
+                    application.getJob().getTitle());
+
+            log.info("Application shortlisted id={}", id);
+            shortlisted++;
+        }
+
+        return new ShortlistResponse(shortlisted, skipped);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/SlotBookingService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/SlotBookingService.java
@@ -1,0 +1,73 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.SlotBookingRequest;
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.ApplicationStatus;
+import com.eaa.recruit.entity.AvailabilitySlot;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.AvailabilitySlotRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * FR-30/31: Candidate books an interview slot.
+ * Double-booking prevented at DB level (unique constraint on booked_by_id)
+ * and via optimistic locking (@Version in BaseEntity).
+ */
+@Service
+public class SlotBookingService {
+
+    private static final Logger log = LoggerFactory.getLogger(SlotBookingService.class);
+
+    private final ApplicationRepository      applicationRepository;
+    private final AvailabilitySlotRepository slotRepository;
+
+    public SlotBookingService(ApplicationRepository applicationRepository,
+                               AvailabilitySlotRepository slotRepository) {
+        this.applicationRepository = applicationRepository;
+        this.slotRepository        = slotRepository;
+    }
+
+    @Transactional
+    public void bookSlot(Long applicationId, SlotBookingRequest request,
+                          AuthenticatedUser principal) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
+
+        if (!application.getCandidate().getId().equals(principal.id())) {
+            throw new BusinessException("You can only book slots for your own applications");
+        }
+
+        if (application.getStatus() != ApplicationStatus.SHORTLISTED) {
+            throw new BusinessException("Interview booking is only allowed for SHORTLISTED applications");
+        }
+
+        AvailabilitySlot slot = slotRepository.findById(request.slotId())
+                .orElseThrow(() -> new ResourceNotFoundException("Slot not found: " + request.slotId()));
+
+        if (slot.isBooked()) {
+            throw new ConflictException("Slot is already booked");
+        }
+
+        try {
+            slot.book(application.getCandidate());
+            slotRepository.save(slot);
+
+            application.bookInterviewSlot(slot);
+            applicationRepository.save(application);
+
+            log.info("Slot booked applicationId={} slotId={} candidateId={}",
+                    applicationId, request.slotId(), principal.id());
+
+        } catch (DataIntegrityViolationException e) {
+            throw new ConflictException("Slot was taken concurrently — please choose another");
+        }
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/SystemHealthService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/SystemHealthService.java
@@ -1,0 +1,85 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.admin.SystemHealthResponse;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.lang.management.ManagementFactory;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * FR-38: System health — DB pool, Redis, Kafka, uptime.
+ */
+@Service
+public class SystemHealthService {
+
+    private static final Logger log = LoggerFactory.getLogger(SystemHealthService.class);
+
+    private final HikariDataSource         dataSource;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final AdminClient              kafkaAdminClient;
+
+    public SystemHealthService(HikariDataSource dataSource,
+                                RedisTemplate<String, String> redisTemplate,
+                                AdminClient kafkaAdminClient) {
+        this.dataSource       = dataSource;
+        this.redisTemplate    = redisTemplate;
+        this.kafkaAdminClient = kafkaAdminClient;
+    }
+
+    public SystemHealthResponse getHealth() {
+        return new SystemHealthResponse(
+                dbHealth(),
+                redisHealth(),
+                kafkaHealth(),
+                uptimeSeconds());
+    }
+
+    private SystemHealthResponse.DatabaseHealth dbHealth() {
+        try {
+            var pool = dataSource.getHikariPoolMXBean();
+            return new SystemHealthResponse.DatabaseHealth(
+                    true,
+                    pool.getActiveConnections(),
+                    pool.getIdleConnections());
+        } catch (Exception e) {
+            log.warn("DB health check failed: {}", e.getMessage());
+            return new SystemHealthResponse.DatabaseHealth(false, 0, 0);
+        }
+    }
+
+    private SystemHealthResponse.RedisHealth redisHealth() {
+        try {
+            Properties info = redisTemplate.getConnectionFactory()
+                    .getConnection()
+                    .serverCommands()
+                    .info("server");
+            String version = info != null ? info.getProperty("redis_version", "unknown") : "unknown";
+            return new SystemHealthResponse.RedisHealth(true, "redis_version=" + version);
+        } catch (Exception e) {
+            log.warn("Redis health check failed: {}", e.getMessage());
+            return new SystemHealthResponse.RedisHealth(false, e.getMessage());
+        }
+    }
+
+    private SystemHealthResponse.KafkaHealth kafkaHealth() {
+        try {
+            var nodes = kafkaAdminClient.describeCluster()
+                    .nodes()
+                    .get(5, TimeUnit.SECONDS);
+            return new SystemHealthResponse.KafkaHealth(true, "brokers=" + nodes.size());
+        } catch (Exception e) {
+            log.warn("Kafka health check failed: {}", e.getMessage());
+            return new SystemHealthResponse.KafkaHealth(false, e.getMessage());
+        }
+    }
+
+    private long uptimeSeconds() {
+        return ManagementFactory.getRuntimeMXBean().getUptime() / 1000;
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/WeightedScoringService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/WeightedScoringService.java
@@ -1,0 +1,51 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * FR-28: Compute weighted final score.
+ * Formula: (cvRelevanceScore * 100 * 0.4) + (examScore * 0.4) + (hardFilterPass ? 100 : 0) * 0.2
+ * If hard filter failed, final score is forced to 0.
+ */
+@Service
+public class WeightedScoringService {
+
+    private static final Logger log = LoggerFactory.getLogger(WeightedScoringService.class);
+
+    private final ApplicationRepository applicationRepository;
+
+    public WeightedScoringService(ApplicationRepository applicationRepository) {
+        this.applicationRepository = applicationRepository;
+    }
+
+    @Transactional
+    public double computeAndPersist(Application application) {
+        double score = compute(application);
+        application.updateFinalScore(score);
+        applicationRepository.save(application);
+        log.info("Final score computed applicationId={} score={}", application.getId(), score);
+        return score;
+    }
+
+    public double compute(Application application) {
+        Boolean hardFilterPassed = application.getHardFilterPassed();
+
+        // Hard filter fail overrides everything
+        if (Boolean.FALSE.equals(hardFilterPassed)) {
+            return 0.0;
+        }
+
+        double cvComponent   = (application.getCvRelevanceScore() != null
+                                ? application.getCvRelevanceScore() * 100 * 0.4 : 0.0);
+        double examComponent = (application.getExamScore() != null
+                                ? application.getExamScore() * 0.4 : 0.0);
+        double hfComponent   = Boolean.TRUE.equals(hardFilterPassed) ? 100 * 0.2 : 0.0;
+
+        return cvComponent + examComponent + hfComponent;
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/XaiReportService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/XaiReportService.java
@@ -1,0 +1,76 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.config.XaiProperties;
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * FR-35: Download XAI PDF report.
+ * Handles both local file paths and HTTP URLs stored in xaiReportUrl.
+ */
+@Service
+public class XaiReportService {
+
+    private static final Logger log = LoggerFactory.getLogger(XaiReportService.class);
+
+    private final ApplicationRepository applicationRepository;
+    private final XaiProperties         xaiProperties;
+
+    public XaiReportService(ApplicationRepository applicationRepository,
+                             XaiProperties xaiProperties) {
+        this.applicationRepository = applicationRepository;
+        this.xaiProperties         = xaiProperties;
+    }
+
+    @Transactional(readOnly = true)
+    public Resource getReport(Long applicationId, AuthenticatedUser principal) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
+
+        if (!application.getCandidate().getId().equals(principal.id())) {
+            throw new BusinessException("You can only access reports for your own applications");
+        }
+
+        String reportUrl = application.getXaiReportUrl();
+        if (reportUrl == null || reportUrl.isBlank()) {
+            throw new BusinessException("XAI report not available yet");
+        }
+
+        return resolveResource(reportUrl);
+    }
+
+    private Resource resolveResource(String reportUrl) {
+        if (reportUrl.startsWith("http://") || reportUrl.startsWith("https://")) {
+            try {
+                return new UrlResource(new URL(reportUrl));
+            } catch (MalformedURLException e) {
+                throw new BusinessException("Invalid XAI report URL");
+            }
+        }
+
+        // Local file path — resolve relative to configured reports dir
+        Path path = Paths.get(xaiProperties.getReportsDir()).resolve(reportUrl).normalize();
+        Resource resource = new FileSystemResource(path);
+        if (!resource.exists()) {
+            throw new ResourceNotFoundException("XAI report file not found");
+        }
+
+        log.info("Serving XAI report from {}", path);
+        return resource;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -112,3 +112,9 @@ internal:
 scheduler:
   job-status:
     cron: ${SCHEDULER_JOB_STATUS_CRON:0 * * * * *}
+  interview-reminder:
+    cron: ${SCHEDULER_REMINDER_CRON:0 0 8 * * *}
+    days-before: ${SCHEDULER_REMINDER_DAYS_BEFORE:1}
+
+xai:
+  reports-dir: ${XAI_REPORTS_DIR:./xai-reports}

--- a/backend/src/main/resources/db/migration/V7__interview_decisions_archive.sql
+++ b/backend/src/main/resources/db/migration/V7__interview_decisions_archive.sql
@@ -1,0 +1,30 @@
+-- V7: Interview booking, final decisions, archive support
+
+-- Add interview slot FK + decision fields to applications
+ALTER TABLE applications
+    ADD COLUMN IF NOT EXISTS interview_slot_id BIGINT REFERENCES availability_slots(id),
+    ADD COLUMN IF NOT EXISTS reminder_sent      BOOLEAN       NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS decision_notes     TEXT,
+    ADD COLUMN IF NOT EXISTS decision_by_id     BIGINT        REFERENCES users(id),
+    ADD COLUMN IF NOT EXISTS decided_at         TIMESTAMPTZ;
+
+CREATE INDEX idx_applications_slot ON applications (interview_slot_id)
+    WHERE interview_slot_id IS NOT NULL;
+
+-- Add booking fields to availability_slots (FR-30, FR-31)
+ALTER TABLE availability_slots
+    ADD COLUMN IF NOT EXISTS booked_by_id BIGINT REFERENCES users(id),
+    ADD COLUMN IF NOT EXISTS booked_at    TIMESTAMPTZ;
+
+-- Unique constraint: one slot per candidate (prevents double-booking at DB level)
+ALTER TABLE availability_slots
+    ADD CONSTRAINT uq_slot_booked_by UNIQUE (booked_by_id)
+    DEFERRABLE INITIALLY IMMEDIATE;
+
+-- Add ARCHIVED status to job_postings (FR-36)
+ALTER TABLE job_postings
+    DROP CONSTRAINT IF EXISTS job_postings_status_check;
+
+ALTER TABLE job_postings
+    ADD CONSTRAINT job_postings_status_check
+    CHECK (status IN ('DRAFT', 'OPEN', 'CLOSED', 'EXAM_SCHEDULED', 'ARCHIVED'));

--- a/backend/src/main/resources/db/migration/V8__create_audit_logs_table.sql
+++ b/backend/src/main/resources/db/migration/V8__create_audit_logs_table.sql
@@ -1,0 +1,16 @@
+-- V8: Audit log — immutable record of all status transitions and admin actions
+
+CREATE TABLE audit_logs (
+    id           BIGSERIAL     PRIMARY KEY,
+    entity_type  VARCHAR(50)   NOT NULL,
+    entity_id    BIGINT        NOT NULL,
+    old_status   VARCHAR(50),
+    new_status   VARCHAR(50)   NOT NULL,
+    changed_by   BIGINT,
+    changed_at   TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    reason       VARCHAR(500)
+);
+
+CREATE INDEX idx_audit_entity    ON audit_logs (entity_type, entity_id);
+CREATE INDEX idx_audit_actor     ON audit_logs (changed_by);
+CREATE INDEX idx_audit_changed_at ON audit_logs (changed_at);

--- a/backend/src/main/resources/db/migration/V9__create_ai_model_versions_table.sql
+++ b/backend/src/main/resources/db/migration/V9__create_ai_model_versions_table.sql
@@ -1,0 +1,13 @@
+-- V9: AI model version registry (FR-39)
+
+CREATE TABLE ai_model_versions (
+    id              BIGSERIAL     PRIMARY KEY,
+    model_version   VARCHAR(100)  NOT NULL,
+    description     TEXT,
+    activated_at    TIMESTAMPTZ   NOT NULL,
+    is_active       BOOLEAN       NOT NULL DEFAULT FALSE,
+    created_by_id   BIGINT        REFERENCES users(id),
+    created_at      TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ai_model_active ON ai_model_versions (is_active);

--- a/backend/src/test/java/com/eaa/recruit/scheduler/InterviewReminderSchedulerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/scheduler/InterviewReminderSchedulerTest.java
@@ -1,0 +1,68 @@
+package com.eaa.recruit.scheduler;
+
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewReminderSchedulerTest {
+
+    @Mock ApplicationRepository     applicationRepository;
+    @Mock CandidateNotificationPort candidateNotificationPort;
+
+    InterviewReminderScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new InterviewReminderScheduler(applicationRepository, candidateNotificationPort);
+    }
+
+    @Test
+    void sendReminders_notifiesAndMarksSent() {
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job  = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now(), LocalDate.now().plusDays(30), LocalDate.now().plusDays(37), recruiter);
+        User candidate  = User.create("c@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        Application app = Application.create(candidate, job, "cv.pdf");
+        app.applyAiScore(0.8, "url");
+        app.markHardFilterPassed();
+        app.authorizeExam("token");
+        app.recordExamScore(80.0, 72.0);
+        app.shortlist();
+
+        AvailabilitySlot slot = AvailabilitySlot.create(recruiter,
+                LocalDate.now().plusDays(1), LocalTime.of(9, 0), LocalTime.of(10, 0));
+        app.bookInterviewSlot(slot);
+
+        when(applicationRepository.findScheduledForDateWithoutReminder(any()))
+                .thenReturn(List.of(app));
+        when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        scheduler.sendReminders();
+
+        verify(candidateNotificationPort).notifyInterviewReminder(any(), any(), any(), any(), any());
+        verify(applicationRepository).save(app);
+    }
+
+    @Test
+    void sendReminders_doesNothingWhenNoUpcoming() {
+        when(applicationRepository.findScheduledForDateWithoutReminder(any()))
+                .thenReturn(List.of());
+
+        scheduler.sendReminders();
+
+        verifyNoInteractions(candidateNotificationPort);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
@@ -1,6 +1,7 @@
 package com.eaa.recruit.service;
 
 import com.eaa.recruit.dto.application.SubmitApplicationResponse;
+import com.eaa.recruit.dto.internal.ExamScoreCallbackRequest;
 import com.eaa.recruit.entity.*;
 import com.eaa.recruit.exception.BusinessException;
 import com.eaa.recruit.exception.ConflictException;
@@ -28,12 +29,13 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class ApplicationServiceTest {
 
-    @Mock ApplicationRepository  applicationRepository;
-    @Mock JobPostingRepository   jobPostingRepository;
-    @Mock UserRepository         userRepository;
-    @Mock FileStorageService     fileStorageService;
-    @Mock KafkaEventPublisher    kafkaEventPublisher;
-    @Mock HardFilterService      hardFilterService;
+    @Mock ApplicationRepository    applicationRepository;
+    @Mock JobPostingRepository     jobPostingRepository;
+    @Mock UserRepository           userRepository;
+    @Mock FileStorageService       fileStorageService;
+    @Mock KafkaEventPublisher      kafkaEventPublisher;
+    @Mock HardFilterService        hardFilterService;
+    @Mock WeightedScoringService   weightedScoringService;
 
     ApplicationService service;
 
@@ -43,7 +45,8 @@ class ApplicationServiceTest {
     @BeforeEach
     void setUp() {
         service = new ApplicationService(applicationRepository, jobPostingRepository,
-                userRepository, fileStorageService, kafkaEventPublisher, hardFilterService);
+                userRepository, fileStorageService, kafkaEventPublisher,
+                hardFilterService, weightedScoringService);
     }
 
     private static User candidateUser() {
@@ -118,5 +121,40 @@ class ApplicationServiceTest {
 
         assertThatThrownBy(() -> service.submitApplication(99L, validCv(), CANDIDATE))
                 .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // FR-27
+    @Test
+    void applyExamScore_recordsScoreAndComputesFinalScore() {
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job  = openJob(recruiter);
+        User candidate  = candidateUser();
+        Application app = Application.create(candidate, job, "cv.pdf");
+        app.applyAiScore(0.8, "http://report");
+        app.markHardFilterPassed();
+        app.authorizeExam("token");
+
+        when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
+        when(weightedScoringService.compute(app)).thenReturn(72.0);
+        when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.applyExamScore(5L, new ExamScoreCallbackRequest(80.0));
+
+        assertThat(app.getStatus()).isEqualTo(ApplicationStatus.EXAM_COMPLETED);
+        assertThat(app.getExamScore()).isEqualTo(80.0);
+    }
+
+    @Test
+    void applyExamScore_throwsBusinessException_whenNotExamAuthorized() {
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job  = openJob(recruiter);
+        User candidate  = candidateUser();
+        Application app = Application.create(candidate, job, "cv.pdf");
+        // status is SUBMITTED, not EXAM_AUTHORIZED
+
+        when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
+
+        assertThatThrownBy(() -> service.applyExamScore(5L, new ExamScoreCallbackRequest(80.0)))
+                .isInstanceOf(BusinessException.class);
     }
 }

--- a/backend/src/test/java/com/eaa/recruit/service/FinalDecisionServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/FinalDecisionServiceTest.java
@@ -1,0 +1,93 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.DecisionRequest;
+import com.eaa.recruit.dto.application.DecisionResponse;
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FinalDecisionServiceTest {
+
+    @Mock ApplicationRepository     applicationRepository;
+    @Mock UserRepository            userRepository;
+    @Mock CandidateNotificationPort candidateNotificationPort;
+    @Mock AuditLogService           auditLogService;
+
+    FinalDecisionService service;
+
+    private static final AuthenticatedUser RECRUITER =
+            new AuthenticatedUser(20L, "r@eaa.com", "RECRUITER");
+
+    @BeforeEach
+    void setUp() {
+        service = new FinalDecisionService(applicationRepository, userRepository,
+                candidateNotificationPort, auditLogService);
+    }
+
+    private Application makeShortlistedApp() {
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job  = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now(), LocalDate.now().plusDays(30), LocalDate.now().plusDays(37), recruiter);
+        User candidate  = User.create("c@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        Application app = Application.create(candidate, job, "cv.pdf");
+        app.applyAiScore(0.8, "url");
+        app.markHardFilterPassed();
+        app.authorizeExam("token");
+        app.recordExamScore(80.0, 72.0);
+        app.shortlist();
+        return app;
+    }
+
+    @Test
+    void recordDecision_selected_updatesStatusAndNotifies() {
+        Application app = makeShortlistedApp();
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+
+        when(applicationRepository.findById(1L)).thenReturn(Optional.of(app));
+        when(userRepository.findById(20L)).thenReturn(Optional.of(recruiter));
+        when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        DecisionResponse response = service.recordDecision(1L,
+                new DecisionRequest(ApplicationStatus.SELECTED, "Great candidate"), RECRUITER);
+
+        assertThat(response.status()).isEqualTo(ApplicationStatus.SELECTED);
+        assertThat(app.getDecisionNotes()).isEqualTo("Great candidate");
+        verify(candidateNotificationPort).notifyDecision(any(), any(), any(), eq("SELECTED"), any());
+        verify(auditLogService).log(any(), eq(1L), any(), eq("SELECTED"), any(), any());
+    }
+
+    @Test
+    void recordDecision_throwsBusinessException_onInvalidDecisionStatus() {
+        // SHORTLISTED is not a valid final decision — validation happens before repo lookup
+        assertThatThrownBy(() -> service.recordDecision(1L,
+                new DecisionRequest(ApplicationStatus.SHORTLISTED, null), RECRUITER))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void recordDecision_throwsResourceNotFoundException_whenNotFound() {
+        when(applicationRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.recordDecision(99L,
+                new DecisionRequest(ApplicationStatus.SELECTED, null), RECRUITER))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/ShortlistServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ShortlistServiceTest.java
@@ -1,0 +1,88 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.ShortlistRequest;
+import com.eaa.recruit.dto.application.ShortlistResponse;
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ShortlistServiceTest {
+
+    @Mock ApplicationRepository     applicationRepository;
+    @Mock CandidateNotificationPort candidateNotificationPort;
+
+    ShortlistService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ShortlistService(applicationRepository, candidateNotificationPort);
+    }
+
+    private Application makeExamCompletedApp(Long fakeId) {
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job  = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now(), LocalDate.now().plusDays(30), LocalDate.now().plusDays(37), recruiter);
+        User candidate  = User.create("c@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        Application app = Application.create(candidate, job, "cv.pdf");
+        app.applyAiScore(0.8, "url");
+        app.markHardFilterPassed();
+        app.authorizeExam("token");
+        app.recordExamScore(80.0, 72.0);
+        return app;
+    }
+
+    @Test
+    void shortlist_shortlistsEligibleApplications() {
+        Application app = makeExamCompletedApp(1L);
+        when(applicationRepository.findById(1L)).thenReturn(Optional.of(app));
+        when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ShortlistResponse response = service.shortlist(new ShortlistRequest(List.of(1L)));
+
+        assertThat(response.shortlisted()).isEqualTo(1);
+        assertThat(response.skipped()).isEqualTo(0);
+        assertThat(app.getStatus()).isEqualTo(ApplicationStatus.SHORTLISTED);
+        verify(candidateNotificationPort).notifyShortlisted(any(), any(), any());
+    }
+
+    @Test
+    void shortlist_skipsNonExamCompletedApplications() {
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job  = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now(), LocalDate.now().plusDays(30), LocalDate.now().plusDays(37), recruiter);
+        User candidate  = User.create("c@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        Application app = Application.create(candidate, job, "cv.pdf"); // SUBMITTED status
+
+        when(applicationRepository.findById(1L)).thenReturn(Optional.of(app));
+
+        ShortlistResponse response = service.shortlist(new ShortlistRequest(List.of(1L)));
+
+        assertThat(response.shortlisted()).isEqualTo(0);
+        assertThat(response.skipped()).isEqualTo(1);
+        verifyNoInteractions(candidateNotificationPort);
+    }
+
+    @Test
+    void shortlist_throwsResourceNotFoundException_whenNotFound() {
+        when(applicationRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.shortlist(new ShortlistRequest(List.of(99L))))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/WeightedScoringServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/WeightedScoringServiceTest.java
@@ -1,0 +1,62 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.repository.ApplicationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+@ExtendWith(MockitoExtension.class)
+class WeightedScoringServiceTest {
+
+    @Mock ApplicationRepository applicationRepository;
+
+    WeightedScoringService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WeightedScoringService(applicationRepository);
+    }
+
+    private Application makeApp(double cvScore, double examScore, Boolean hfPassed) {
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job  = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now(), LocalDate.now().plusDays(30), LocalDate.now().plusDays(37), recruiter);
+        User candidate  = User.create("c@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        Application app = Application.create(candidate, job, "cv.pdf");
+        app.applyAiScore(cvScore, "url");
+        if (Boolean.TRUE.equals(hfPassed))  app.markHardFilterPassed();
+        if (Boolean.FALSE.equals(hfPassed)) app.markHardFilterFailed();
+        app.authorizeExam("token");
+        app.recordExamScore(examScore, 0.0); // finalScore placeholder
+        return app;
+    }
+
+    @Test
+    void compute_fullScore_whenAllPassed() {
+        Application app = makeApp(1.0, 100.0, true);
+        // (1.0 * 100 * 0.4) + (100.0 * 0.4) + (100 * 0.2) = 40 + 40 + 20 = 100
+        double score = service.compute(app);
+        assertThat(score).isCloseTo(100.0, offset(0.001));
+    }
+
+    @Test
+    void compute_zeroScore_whenHardFilterFailed() {
+        Application app = makeApp(0.9, 85.0, false);
+        assertThat(service.compute(app)).isEqualTo(0.0);
+    }
+
+    @Test
+    void compute_partialScore_whenHardFilterPassedWithLowerScores() {
+        Application app = makeApp(0.5, 50.0, true);
+        // (0.5 * 100 * 0.4) + (50 * 0.4) + (100 * 0.2) = 20 + 20 + 20 = 60
+        assertThat(service.compute(app)).isCloseTo(60.0, offset(0.001));
+    }
+}


### PR DESCRIPTION
## Summary

- FR-26: fix `ExamService` — pass `job.examDate` as `scheduledAt` in `EXAM_BATCH_READY` event
- FR-27: exam score ingestion from Go engine (`POST /api/v1/internal/applications/{id}/exam-score`)
- FR-28: `WeightedScoringService` — `(cv*100*0.4) + (exam*0.4) + (hf?100:0)*0.2`; hard-filter fail → 0
- FR-29: batch shortlist endpoint (`POST /api/v1/applications/shortlist`)
- FR-30/31: slot booking with DB-level double-booking prevention (unique constraint + `@Version` optimistic lock)
- FR-32: `InterviewReminderScheduler` — daily cron, sends reminder N days before interview, idempotent
- FR-33: final decision (`POST /api/v1/applications/{id}/decision`) — SELECTED/REJECTED/WAITLISTED
- FR-34: feedback report (`GET /api/v1/applications/{id}/feedback`) — candidate view after decision
- FR-35: XAI PDF download (`GET /api/v1/applications/{id}/xai-report`) — handles local paths and HTTP URLs
- FR-36: job archiving (`POST /api/v1/admin/jobs/{id}/archive`)
- FR-37: audit log access (`GET /api/v1/admin/audit-logs`)
- FR-38: system health (`GET /api/v1/admin/system/health`) — HikariCP pool, Redis INFO, Kafka broker count, JVM uptime
- FR-39: AI model version registry (`/api/v1/admin/ai-models`) — register, activate, list
- FR-40: analytics export (`GET /api/v1/analytics/export`)

## New / changed files

- 3 Flyway migrations (V7–V9): interview/decision/archive schema, audit_logs, ai_model_versions
- 2 new entities: `AuditLog`, `AiModelVersion`
- Entity updates: `Application` (decision fields + interview slot), `AvailabilitySlot` (booking fields), `JobPosting`/`Status` (ARCHIVED)
- 13 new services, 5 new controllers, 12 new DTOs, 2 new repositories
- `KafkaConfig` adds `AdminClient` bean; `XaiProperties` config property
- 4 new test classes, updated `ApplicationServiceTest`

## Test plan

- [ ] `WeightedScoringServiceTest` — formula boundary cases (full 100, hard-filter fail → 0, partial)
- [ ] `ShortlistServiceTest` — eligible vs. skipped, not-found
- [ ] `FinalDecisionServiceTest` — select/reject/waitlist, invalid status, not-found
- [ ] `InterviewReminderSchedulerTest` — notifies and marks sent, no-op when empty
- [ ] `ApplicationServiceTest` — FR-27 happy path + wrong-status guard
- [ ] Full suite: `./gradlew test` (pre-existing infra-dependent failures unaffected)