### PR TITLE
feat(backend): complete exam score ingestion endpoint [FR-27]

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/dto/internal/ExamScoreCallbackRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/internal/ExamScoreCallbackRequest.java
@@ -3,11 +3,18 @@ package com.eaa.recruit.dto.internal;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.time.Instant;
 
 public record ExamScoreCallbackRequest(
 
         @NotNull(message = "examScore is required")
         @DecimalMin(value = "0.0", message = "examScore must be >= 0")
         @DecimalMax(value = "100.0", message = "examScore must be <= 100")
-        Double examScore
+        Double examScore,
+
+        @NotNull(message = "completedAt is required")
+        @PastOrPresent(message = "completedAt must not be in the future")
+        Instant completedAt
 ) {}

--- a/backend/src/main/java/com/eaa/recruit/entity/Application.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/Application.java
@@ -61,6 +61,9 @@ public class Application extends BaseEntity {
     @Column(name = "submitted_at", nullable = false, updatable = false)
     private Instant submittedAt;
 
+    @Column(name = "exam_completed_at")
+    private Instant examCompletedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "interview_slot_id")
     private AvailabilitySlot interviewSlot;
@@ -105,6 +108,7 @@ public class Application extends BaseEntity {
     public String            getXaiReportUrl()     { return xaiReportUrl; }
     public String            getExamToken()        { return examToken; }
     public Instant           getSubmittedAt()      { return submittedAt; }
+    public Instant           getExamCompletedAt()  { return examCompletedAt; }
     public AvailabilitySlot  getInterviewSlot()    { return interviewSlot; }
     public boolean           isReminderSent()      { return reminderSent; }
     public String            getDecisionNotes()    { return decisionNotes; }
@@ -137,10 +141,11 @@ public class Application extends BaseEntity {
         this.status    = ApplicationStatus.EXAM_AUTHORIZED;
     }
 
-    public void recordExamScore(double score, double computedFinalScore) {
-        this.examScore  = score;
-        this.finalScore = computedFinalScore;
-        this.status     = ApplicationStatus.EXAM_COMPLETED;
+    public void recordExamScore(double score, double computedFinalScore, Instant completedAt) {
+        this.examScore        = score;
+        this.finalScore       = computedFinalScore;
+        this.examCompletedAt  = completedAt;
+        this.status           = ApplicationStatus.EXAM_COMPLETED;
     }
 
     public void shortlist() {

--- a/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
@@ -116,15 +116,21 @@ public class ApplicationService {
         Application application = applicationRepository.findById(applicationId)
                 .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
 
+        // Idempotency — duplicate callback for an already-completed exam is a no-op
+        if (application.getStatus() == ApplicationStatus.EXAM_COMPLETED) {
+            log.info("Exam score already applied applicationId={} — ignoring duplicate callback", applicationId);
+            return;
+        }
+
         if (application.getStatus() != ApplicationStatus.EXAM_AUTHORIZED) {
             throw new BusinessException("Exam score can only be applied to EXAM_AUTHORIZED applications");
         }
 
         double finalScore = weightedScoringService.compute(application);
-        application.recordExamScore(request.examScore(), finalScore);
+        application.recordExamScore(request.examScore(), finalScore, request.completedAt());
         applicationRepository.save(application);
 
-        log.info("Exam score applied applicationId={} examScore={} finalScore={}",
-                applicationId, request.examScore(), finalScore);
+        log.info("Exam score applied applicationId={} examScore={} finalScore={} completedAt={}",
+                applicationId, request.examScore(), finalScore, request.completedAt());
     }
 }

--- a/backend/src/main/resources/db/migration/V10__add_exam_completed_at.sql
+++ b/backend/src/main/resources/db/migration/V10__add_exam_completed_at.sql
@@ -1,0 +1,4 @@
+-- V10: Track when exam score callback was received (FR-27)
+
+ALTER TABLE applications
+    ADD COLUMN IF NOT EXISTS exam_completed_at TIMESTAMPTZ;

--- a/backend/src/test/java/com/eaa/recruit/scheduler/InterviewReminderSchedulerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/scheduler/InterviewReminderSchedulerTest.java
@@ -39,7 +39,7 @@ class InterviewReminderSchedulerTest {
         app.applyAiScore(0.8, "url");
         app.markHardFilterPassed();
         app.authorizeExam("token");
-        app.recordExamScore(80.0, 72.0);
+        app.recordExamScore(80.0, 72.0, java.time.Instant.now());
         app.shortlist();
 
         AvailabilitySlot slot = AvailabilitySlot.create(recruiter,

--- a/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -138,10 +139,12 @@ class ApplicationServiceTest {
         when(weightedScoringService.compute(app)).thenReturn(72.0);
         when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        service.applyExamScore(5L, new ExamScoreCallbackRequest(80.0));
+        Instant completedAt = Instant.now();
+        service.applyExamScore(5L, new ExamScoreCallbackRequest(80.0, completedAt));
 
         assertThat(app.getStatus()).isEqualTo(ApplicationStatus.EXAM_COMPLETED);
         assertThat(app.getExamScore()).isEqualTo(80.0);
+        assertThat(app.getExamCompletedAt()).isEqualTo(completedAt);
     }
 
     @Test
@@ -154,7 +157,29 @@ class ApplicationServiceTest {
 
         when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
 
-        assertThatThrownBy(() -> service.applyExamScore(5L, new ExamScoreCallbackRequest(80.0)))
+        assertThatThrownBy(() -> service.applyExamScore(5L, new ExamScoreCallbackRequest(80.0, Instant.now())))
                 .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void applyExamScore_isIdempotent_whenAlreadyCompleted() {
+        User recruiter  = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        JobPosting job  = openJob(recruiter);
+        User candidate  = candidateUser();
+        Application app = Application.create(candidate, job, "cv.pdf");
+        app.applyAiScore(0.8, "http://report");
+        app.markHardFilterPassed();
+        app.authorizeExam("token");
+        app.recordExamScore(80.0, 72.0, Instant.now());
+        // status now EXAM_COMPLETED
+
+        when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
+
+        // Duplicate callback must not throw and must not re-save or recompute
+        service.applyExamScore(5L, new ExamScoreCallbackRequest(95.0, Instant.now()));
+
+        assertThat(app.getExamScore()).isEqualTo(80.0); // unchanged
+        verify(applicationRepository, never()).save(any());
+        verifyNoInteractions(weightedScoringService);
     }
 }

--- a/backend/src/test/java/com/eaa/recruit/service/FinalDecisionServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/FinalDecisionServiceTest.java
@@ -51,7 +51,7 @@ class FinalDecisionServiceTest {
         app.applyAiScore(0.8, "url");
         app.markHardFilterPassed();
         app.authorizeExam("token");
-        app.recordExamScore(80.0, 72.0);
+        app.recordExamScore(80.0, 72.0, java.time.Instant.now());
         app.shortlist();
         return app;
     }

--- a/backend/src/test/java/com/eaa/recruit/service/ShortlistServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ShortlistServiceTest.java
@@ -43,7 +43,7 @@ class ShortlistServiceTest {
         app.applyAiScore(0.8, "url");
         app.markHardFilterPassed();
         app.authorizeExam("token");
-        app.recordExamScore(80.0, 72.0);
+        app.recordExamScore(80.0, 72.0, java.time.Instant.now());
         return app;
     }
 

--- a/backend/src/test/java/com/eaa/recruit/service/WeightedScoringServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/WeightedScoringServiceTest.java
@@ -35,7 +35,7 @@ class WeightedScoringServiceTest {
         if (Boolean.TRUE.equals(hfPassed))  app.markHardFilterPassed();
         if (Boolean.FALSE.equals(hfPassed)) app.markHardFilterFailed();
         app.authorizeExam("token");
-        app.recordExamScore(examScore, 0.0); // finalScore placeholder
+        app.recordExamScore(examScore, 0.0, java.time.Instant.now()); // finalScore placeholder
         return app;
     }
 


### PR DESCRIPTION
Closes #118

## Summary
- `POST /api/v1/internal/applications/{id}/exam-score` now accepts full `{ examScore, completedAt }` payload per AC
- Callback is idempotent — a second callback on an already-completed exam is a no-op (no exception, no re-save)
- Adds `exam_completed_at` column to `applications` (Flyway V10) for audit/telemetry
- Keeps existing auth (`X-Internal-Api-Key`), 0–100 validation, and 404 on missing application

## Test plan
- [x] `ApplicationServiceTest.applyExamScore_recordsScoreAndComputesFinalScore` — asserts `examCompletedAt` is persisted
- [x] `ApplicationServiceTest.applyExamScore_isIdempotent_whenAlreadyCompleted` — duplicate callback is no-op
- [x] `ApplicationServiceTest.applyExamScore_throwsBusinessException_whenNotExamAuthorized` — wrong state still rejected
- [x] All downstream tests using `recordExamScore(...)` updated for new signature
- [ ] Manual: invoke endpoint twice with same application id — second call returns 200 without state change

