### PR TITLE
feat(backend): audit log service and admin system health API (FR-37, FR-38)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/AdminSystemController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AdminSystemController.java
@@ -7,6 +7,7 @@ import com.eaa.recruit.dto.admin.AuditLogResponse;
 import com.eaa.recruit.dto.admin.SystemHealthResponse;
 import com.eaa.recruit.entity.AuditLog;
 import com.eaa.recruit.repository.AuditLogRepository;
+import com.eaa.recruit.repository.AuditLogSpecifications;
 import com.eaa.recruit.security.AuthenticatedUser;
 import com.eaa.recruit.security.rbac.IsAdmin;
 import com.eaa.recruit.security.rbac.IsSuperAdmin;
@@ -16,11 +17,15 @@ import com.eaa.recruit.service.SystemHealthService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -59,13 +64,28 @@ public class AdminSystemController {
         return ResponseEntity.ok(ApiResponse.success("Job archived"));
     }
 
-    /** GET /api/v1/admin/audit-logs — FR-37 */
+    /**
+     * GET /api/v1/admin/audit-logs — FR-37
+     * Paginated, filterable by entity type, entity id, actor id, and date range.
+     */
     @IsAdmin
     @GetMapping("/audit-logs")
     public ResponseEntity<ApiResponse<List<AuditLogResponse>>> getAuditLogs(
-            @PageableDefault(size = 20) Pageable pageable) {
+            @RequestParam(required = false) String entityType,
+            @RequestParam(required = false) Long entityId,
+            @RequestParam(required = false) Long actorId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+            @PageableDefault(size = 20, sort = "changedAt") Pageable pageable) {
 
-        Page<AuditLog> page = auditLogRepository.findAllByOrderByChangedAtDesc(pageable);
+        Specification<AuditLog> spec = Specification
+                .where(AuditLogSpecifications.entityTypeIs(entityType))
+                .and(AuditLogSpecifications.entityIdIs(entityId))
+                .and(AuditLogSpecifications.actorIs(actorId))
+                .and(AuditLogSpecifications.changedAfter(from))
+                .and(AuditLogSpecifications.changedBefore(to));
+
+        Page<AuditLog> page = auditLogRepository.findAll(spec, pageable);
         List<AuditLogResponse> responses = page.stream().map(this::toResponse).toList();
         return ResponseEntity.ok(ApiResponse.success(responses));
     }
@@ -84,11 +104,17 @@ public class AdminSystemController {
         return ResponseEntity.ok(ApiResponse.success(responses));
     }
 
-    /** GET /api/v1/admin/system/health — FR-38 */
-    @IsSuperAdmin
-    @GetMapping("/system/health")
+    /**
+     * GET /api/v1/admin/system-health — FR-38
+     * Real-time snapshot of DB pool, Redis, Kafka lag, and uptime.
+     * Never cached — response carries Cache-Control: no-store.
+     */
+    @IsAdmin
+    @GetMapping("/system-health")
     public ResponseEntity<ApiResponse<SystemHealthResponse>> getSystemHealth() {
-        return ResponseEntity.ok(ApiResponse.success(systemHealthService.getHealth()));
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noStore())
+                .body(ApiResponse.success(systemHealthService.getHealth()));
     }
 
     /** POST /api/v1/admin/ai-models — FR-39 */

--- a/backend/src/main/java/com/eaa/recruit/controller/AdminUserController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AdminUserController.java
@@ -34,9 +34,10 @@ public class AdminUserController {
      */
     @PostMapping("/recruiter")
     public ResponseEntity<ApiResponse<RecruiterCreatedResponse>> createRecruiter(
-            @Valid @RequestBody CreateRecruiterRequest request) {
+            @Valid @RequestBody CreateRecruiterRequest request,
+            @AuthenticationPrincipal AuthenticatedUser requester) {
 
-        RecruiterCreatedResponse response = recruiterAdminService.createRecruiter(request);
+        RecruiterCreatedResponse response = recruiterAdminService.createRecruiter(request, requester);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("Recruiter account created successfully", response));
     }

--- a/backend/src/main/java/com/eaa/recruit/controller/ShortlistController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/ShortlistController.java
@@ -3,10 +3,12 @@ package com.eaa.recruit.controller;
 import com.eaa.recruit.dto.ApiResponse;
 import com.eaa.recruit.dto.application.ShortlistRequest;
 import com.eaa.recruit.dto.application.ShortlistResponse;
+import com.eaa.recruit.security.AuthenticatedUser;
 import com.eaa.recruit.security.rbac.IsRecruiter;
 import com.eaa.recruit.service.ShortlistService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -26,9 +28,10 @@ public class ShortlistController {
     @IsRecruiter
     @PostMapping("/shortlist")
     public ResponseEntity<ApiResponse<ShortlistResponse>> shortlist(
-            @Valid @RequestBody ShortlistRequest request) {
+            @Valid @RequestBody ShortlistRequest request,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
 
-        ShortlistResponse response = shortlistService.shortlist(request);
+        ShortlistResponse response = shortlistService.shortlist(request, principal);
         return ResponseEntity.ok(ApiResponse.success("Shortlisting complete", response));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/SystemHealthResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/SystemHealthResponse.java
@@ -1,15 +1,46 @@
 package com.eaa.recruit.dto.admin;
 
+import java.util.List;
+import java.util.Map;
+
+/**
+ * FR-38: System health snapshot. Each sub-resource carries a {@link Status}
+ * level so dashboards can alert without re-interpreting raw metrics.
+ */
 public record SystemHealthResponse(
-        DatabaseHealth database,
-        RedisHealth redis,
-        KafkaHealth kafka,
-        long uptimeSeconds
+        Status           overall,
+        DatabaseHealth   database,
+        RedisHealth      redis,
+        KafkaHealth      kafka,
+        long             uptimeSeconds
 ) {
 
-    public record DatabaseHealth(boolean up, int activeConnections, int idleConnections) {}
+    public enum Status { OK, WARNING, CRITICAL }
 
-    public record RedisHealth(boolean up, String info) {}
+    public record DatabaseHealth(
+            Status status,
+            boolean up,
+            int activeConnections,
+            int idleConnections,
+            int totalConnections,
+            int maxPoolSize) {}
 
-    public record KafkaHealth(boolean up, String details) {}
+    public record RedisHealth(
+            Status status,
+            boolean up,
+            Long   keyspaceHits,
+            Long   keyspaceMisses,
+            Double hitRatio,
+            String details) {}
+
+    public record KafkaHealth(
+            Status          status,
+            boolean         up,
+            int             brokerCount,
+            long            totalConsumerLag,
+            List<TopicLag>  topicLags,
+            String          details) {
+
+        public record TopicLag(String topic, String consumerGroup, Map<Integer, Long> partitionLag, long total) {}
+    }
 }

--- a/backend/src/main/java/com/eaa/recruit/entity/AuditLog.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/AuditLog.java
@@ -1,15 +1,22 @@
 package com.eaa.recruit.entity;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.Immutable;
 
 import java.time.Instant;
 
+/**
+ * FR-37: Append-only audit record. Rows are immutable at the JPA layer —
+ * Hibernate will not issue UPDATEs for instances of this entity.
+ */
 @Entity
+@Immutable
 @Table(
     name = "audit_logs",
     indexes = {
-        @Index(name = "idx_audit_entity", columnList = "entity_type, entity_id"),
-        @Index(name = "idx_audit_changed_at", columnList = "changed_at")
+        @Index(name = "idx_audit_entity",       columnList = "entity_type, entity_id"),
+        @Index(name = "idx_audit_actor",        columnList = "changed_by"),
+        @Index(name = "idx_audit_changed_at",   columnList = "changed_at")
     }
 )
 public class AuditLog {
@@ -18,26 +25,26 @@ public class AuditLog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "entity_type", nullable = false, length = 50)
+    @Column(name = "entity_type", nullable = false, updatable = false, length = 50)
     private String entityType;
 
-    @Column(name = "entity_id", nullable = false)
+    @Column(name = "entity_id", nullable = false, updatable = false)
     private Long entityId;
 
-    @Column(name = "old_status", length = 50)
+    @Column(name = "old_status", updatable = false, length = 50)
     private String oldStatus;
 
-    @Column(name = "new_status", nullable = false, length = 50)
+    @Column(name = "new_status", nullable = false, updatable = false, length = 50)
     private String newStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "changed_by")
+    @JoinColumn(name = "changed_by", updatable = false)
     private User changedBy;
 
-    @Column(name = "changed_at", nullable = false)
+    @Column(name = "changed_at", nullable = false, updatable = false)
     private Instant changedAt;
 
-    @Column(name = "reason", length = 500)
+    @Column(name = "reason", updatable = false, length = 500)
     private String reason;
 
     protected AuditLog() {}

--- a/backend/src/main/java/com/eaa/recruit/repository/AuditLogRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/AuditLogRepository.java
@@ -4,8 +4,10 @@ import com.eaa.recruit.entity.AuditLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+public interface AuditLogRepository
+        extends JpaRepository<AuditLog, Long>, JpaSpecificationExecutor<AuditLog> {
 
     Page<AuditLog> findByEntityTypeAndEntityIdOrderByChangedAtDesc(
             String entityType, Long entityId, Pageable pageable);

--- a/backend/src/main/java/com/eaa/recruit/repository/AuditLogSpecifications.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/AuditLogSpecifications.java
@@ -1,0 +1,39 @@
+package com.eaa.recruit.repository;
+
+import com.eaa.recruit.entity.AuditLog;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.Instant;
+
+/**
+ * FR-37: composable query filters for /admin/audit-logs.
+ */
+public final class AuditLogSpecifications {
+
+    private AuditLogSpecifications() {}
+
+    public static Specification<AuditLog> entityTypeIs(String entityType) {
+        return (root, q, cb) -> entityType == null ? null
+                : cb.equal(cb.upper(root.get("entityType")), entityType.toUpperCase());
+    }
+
+    public static Specification<AuditLog> entityIdIs(Long entityId) {
+        return (root, q, cb) -> entityId == null ? null
+                : cb.equal(root.get("entityId"), entityId);
+    }
+
+    public static Specification<AuditLog> actorIs(Long actorId) {
+        return (root, q, cb) -> actorId == null ? null
+                : cb.equal(root.get("changedBy").get("id"), actorId);
+    }
+
+    public static Specification<AuditLog> changedAfter(Instant from) {
+        return (root, q, cb) -> from == null ? null
+                : cb.greaterThanOrEqualTo(root.get("changedAt"), from);
+    }
+
+    public static Specification<AuditLog> changedBefore(Instant to) {
+        return (root, q, cb) -> to == null ? null
+                : cb.lessThanOrEqualTo(root.get("changedAt"), to);
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
@@ -35,6 +35,7 @@ public class ApplicationService {
     private final KafkaEventPublisher    kafkaEventPublisher;
     private final HardFilterService      hardFilterService;
     private final WeightedScoringService weightedScoringService;
+    private final AuditLogService        auditLogService;
 
     public ApplicationService(ApplicationRepository applicationRepository,
                                JobPostingRepository jobPostingRepository,
@@ -42,7 +43,8 @@ public class ApplicationService {
                                FileStorageService fileStorageService,
                                KafkaEventPublisher kafkaEventPublisher,
                                HardFilterService hardFilterService,
-                               WeightedScoringService weightedScoringService) {
+                               WeightedScoringService weightedScoringService,
+                               AuditLogService auditLogService) {
         this.applicationRepository = applicationRepository;
         this.jobPostingRepository  = jobPostingRepository;
         this.userRepository        = userRepository;
@@ -50,6 +52,7 @@ public class ApplicationService {
         this.kafkaEventPublisher   = kafkaEventPublisher;
         this.hardFilterService     = hardFilterService;
         this.weightedScoringService = weightedScoringService;
+        this.auditLogService       = auditLogService;
     }
 
     /** FR-19: Submit application with CV upload. */
@@ -101,10 +104,13 @@ public class ApplicationService {
         Application application = applicationRepository.findById(applicationId)
                 .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
 
+        ApplicationStatus oldStatus = application.getStatus();
         application.applyAiScore(request.cvRelevanceScore(), request.xaiReportUrl());
         applicationRepository.save(application);
 
         log.info("AI score applied applicationId={} score={}", applicationId, request.cvRelevanceScore());
+        auditLogService.log("APPLICATION", applicationId, oldStatus.name(),
+                application.getStatus().name(), null, "AI score callback");
 
         // FR-22: immediately run hard filter after AI score is recorded
         hardFilterService.applyHardFilter(application);
@@ -126,11 +132,14 @@ public class ApplicationService {
             throw new BusinessException("Exam score can only be applied to EXAM_AUTHORIZED applications");
         }
 
+        ApplicationStatus oldStatus = application.getStatus();
         double finalScore = weightedScoringService.compute(application);
         application.recordExamScore(request.examScore(), finalScore, request.completedAt());
         applicationRepository.save(application);
 
         log.info("Exam score applied applicationId={} examScore={} finalScore={} completedAt={}",
                 applicationId, request.examScore(), finalScore, request.completedAt());
+        auditLogService.log("APPLICATION", applicationId, oldStatus.name(),
+                application.getStatus().name(), null, "Exam score callback");
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/service/ExamService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ExamService.java
@@ -15,6 +15,7 @@ import com.eaa.recruit.notification.CandidateNotificationPort;
 import com.eaa.recruit.repository.ApplicationRepository;
 import com.eaa.recruit.repository.ExamRepository;
 import com.eaa.recruit.repository.JobPostingRepository;
+import com.eaa.recruit.repository.UserRepository;
 import com.eaa.recruit.security.AuthenticatedUser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,19 +40,25 @@ public class ExamService {
     private final CandidateNotificationPort candidateNotificationPort;
     private final KafkaEventPublisher       kafkaEventPublisher;
     private final ObjectMapper              objectMapper;
+    private final AuditLogService           auditLogService;
+    private final UserRepository            userRepository;
 
     public ExamService(ExamRepository examRepository,
                        JobPostingRepository jobPostingRepository,
                        ApplicationRepository applicationRepository,
                        CandidateNotificationPort candidateNotificationPort,
                        KafkaEventPublisher kafkaEventPublisher,
-                       ObjectMapper objectMapper) {
+                       ObjectMapper objectMapper,
+                       AuditLogService auditLogService,
+                       UserRepository userRepository) {
         this.examRepository            = examRepository;
         this.jobPostingRepository      = jobPostingRepository;
         this.applicationRepository     = applicationRepository;
         this.candidateNotificationPort = candidateNotificationPort;
         this.kafkaEventPublisher       = kafkaEventPublisher;
         this.objectMapper              = objectMapper;
+        this.auditLogService           = auditLogService;
+        this.userRepository            = userRepository;
     }
 
     /** FR-24: Create exam definition for a job posting. */
@@ -125,6 +132,7 @@ public class ExamService {
             }
 
             String token = UUID.randomUUID().toString();
+            ApplicationStatus oldStatus = application.getStatus();
             application.authorizeExam(token);
             applicationRepository.save(application);
 
@@ -135,6 +143,10 @@ public class ExamService {
 
             authorizedIds.add(appId);
             log.info("Exam authorized applicationId={} candidateId={}", appId, candidate.getId());
+            auditLogService.log("APPLICATION", appId, oldStatus.name(),
+                    application.getStatus().name(),
+                    userRepository.getReferenceById(principal.id()),
+                    "Batch exam authorization");
         }
 
         if (!authorizedIds.isEmpty()) {

--- a/backend/src/main/java/com/eaa/recruit/service/HardFilterService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/HardFilterService.java
@@ -1,6 +1,7 @@
 package com.eaa.recruit.service;
 
 import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.ApplicationStatus;
 import com.eaa.recruit.entity.JobPosting;
 import com.eaa.recruit.entity.User;
 import com.eaa.recruit.notification.CandidateNotificationPort;
@@ -17,11 +18,14 @@ public class HardFilterService {
 
     private final ApplicationRepository       applicationRepository;
     private final CandidateNotificationPort   candidateNotificationPort;
+    private final AuditLogService             auditLogService;
 
     public HardFilterService(ApplicationRepository applicationRepository,
-                              CandidateNotificationPort candidateNotificationPort) {
+                              CandidateNotificationPort candidateNotificationPort,
+                              AuditLogService auditLogService) {
         this.applicationRepository     = applicationRepository;
         this.candidateNotificationPort = candidateNotificationPort;
+        this.auditLogService           = auditLogService;
     }
 
     /**
@@ -38,6 +42,7 @@ public class HardFilterService {
                       && passesWeightCheck(candidate, job)
                       && passesDegreeCheck(candidate, job);
 
+        ApplicationStatus oldStatus = application.getStatus();
         if (passed) {
             application.markHardFilterPassed();
             log.info("Hard filter PASSED applicationId={}", application.getId());
@@ -51,6 +56,11 @@ public class HardFilterService {
         }
 
         applicationRepository.save(application);
+
+        if (oldStatus != application.getStatus()) {
+            auditLogService.log("APPLICATION", application.getId(), oldStatus.name(),
+                    application.getStatus().name(), null, "Hard filter evaluation");
+        }
     }
 
     private boolean passesHeightCheck(User candidate, JobPosting job) {

--- a/backend/src/main/java/com/eaa/recruit/service/RecruiterAdminService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/RecruiterAdminService.java
@@ -7,6 +7,7 @@ import com.eaa.recruit.entity.User;
 import com.eaa.recruit.exception.ConflictException;
 import com.eaa.recruit.notification.WelcomeNotificationPort;
 import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,17 +22,20 @@ public class RecruiterAdminService {
     private final UserRepository          userRepository;
     private final PasswordEncoder         passwordEncoder;
     private final WelcomeNotificationPort welcomeNotification;
+    private final AuditLogService         auditLogService;
 
     public RecruiterAdminService(UserRepository userRepository,
                                  PasswordEncoder passwordEncoder,
-                                 WelcomeNotificationPort welcomeNotification) {
-        this.userRepository     = userRepository;
-        this.passwordEncoder    = passwordEncoder;
+                                 WelcomeNotificationPort welcomeNotification,
+                                 AuditLogService auditLogService) {
+        this.userRepository      = userRepository;
+        this.passwordEncoder     = passwordEncoder;
         this.welcomeNotification = welcomeNotification;
+        this.auditLogService     = auditLogService;
     }
 
     @Transactional
-    public RecruiterCreatedResponse createRecruiter(CreateRecruiterRequest request) {
+    public RecruiterCreatedResponse createRecruiter(CreateRecruiterRequest request, AuthenticatedUser requester) {
         if (userRepository.existsByEmail(request.email())) {
             throw new ConflictException("Email is already registered: " + request.email());
         }
@@ -42,6 +46,9 @@ public class RecruiterAdminService {
         recruiter = userRepository.save(recruiter);
 
         log.info("Recruiter account created id={} email='{}'", recruiter.getId(), recruiter.getEmail());
+        auditLogService.log("USER", recruiter.getId(), null, "RECRUITER_CREATED",
+                userRepository.getReferenceById(requester.id()),
+                "Admin created recruiter " + recruiter.getEmail());
 
         try {
             welcomeNotification.sendRecruiterWelcome(

--- a/backend/src/main/java/com/eaa/recruit/service/ShortlistService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ShortlistService.java
@@ -7,6 +7,8 @@ import com.eaa.recruit.entity.ApplicationStatus;
 import com.eaa.recruit.exception.ResourceNotFoundException;
 import com.eaa.recruit.notification.CandidateNotificationPort;
 import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -22,15 +24,21 @@ public class ShortlistService {
 
     private final ApplicationRepository     applicationRepository;
     private final CandidateNotificationPort candidateNotificationPort;
+    private final AuditLogService           auditLogService;
+    private final UserRepository            userRepository;
 
     public ShortlistService(ApplicationRepository applicationRepository,
-                             CandidateNotificationPort candidateNotificationPort) {
+                             CandidateNotificationPort candidateNotificationPort,
+                             AuditLogService auditLogService,
+                             UserRepository userRepository) {
         this.applicationRepository     = applicationRepository;
         this.candidateNotificationPort = candidateNotificationPort;
+        this.auditLogService           = auditLogService;
+        this.userRepository            = userRepository;
     }
 
     @Transactional
-    public ShortlistResponse shortlist(ShortlistRequest request) {
+    public ShortlistResponse shortlist(ShortlistRequest request, AuthenticatedUser principal) {
         int shortlisted = 0;
         int skipped     = 0;
 
@@ -43,6 +51,7 @@ public class ShortlistService {
                 continue;
             }
 
+            ApplicationStatus oldStatus = application.getStatus();
             application.shortlist();
             applicationRepository.save(application);
 
@@ -52,6 +61,10 @@ public class ShortlistService {
                     application.getJob().getTitle());
 
             log.info("Application shortlisted id={}", id);
+            auditLogService.log("APPLICATION", id, oldStatus.name(),
+                    application.getStatus().name(),
+                    userRepository.getReferenceById(principal.id()),
+                    "Recruiter shortlist");
             shortlisted++;
         }
 

--- a/backend/src/main/java/com/eaa/recruit/service/SlotBookingService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/SlotBookingService.java
@@ -9,6 +9,7 @@ import com.eaa.recruit.exception.ConflictException;
 import com.eaa.recruit.exception.ResourceNotFoundException;
 import com.eaa.recruit.repository.ApplicationRepository;
 import com.eaa.recruit.repository.AvailabilitySlotRepository;
+import com.eaa.recruit.repository.UserRepository;
 import com.eaa.recruit.security.AuthenticatedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,11 +29,17 @@ public class SlotBookingService {
 
     private final ApplicationRepository      applicationRepository;
     private final AvailabilitySlotRepository slotRepository;
+    private final AuditLogService            auditLogService;
+    private final UserRepository             userRepository;
 
     public SlotBookingService(ApplicationRepository applicationRepository,
-                               AvailabilitySlotRepository slotRepository) {
+                               AvailabilitySlotRepository slotRepository,
+                               AuditLogService auditLogService,
+                               UserRepository userRepository) {
         this.applicationRepository = applicationRepository;
         this.slotRepository        = slotRepository;
+        this.auditLogService       = auditLogService;
+        this.userRepository        = userRepository;
     }
 
     @Transactional
@@ -57,6 +64,7 @@ public class SlotBookingService {
         }
 
         try {
+            ApplicationStatus oldStatus = application.getStatus();
             slot.book(application.getCandidate());
             slotRepository.save(slot);
 
@@ -65,6 +73,10 @@ public class SlotBookingService {
 
             log.info("Slot booked applicationId={} slotId={} candidateId={}",
                     applicationId, request.slotId(), principal.id());
+            auditLogService.log("APPLICATION", applicationId, oldStatus.name(),
+                    application.getStatus().name(),
+                    userRepository.getReferenceById(principal.id()),
+                    "Candidate booked interview slot " + request.slotId());
 
         } catch (DataIntegrityViolationException e) {
             throw new ConflictException("Slot was taken concurrently — please choose another");

--- a/backend/src/main/java/com/eaa/recruit/service/SystemHealthService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/SystemHealthService.java
@@ -1,28 +1,52 @@
 package com.eaa.recruit.service;
 
 import com.eaa.recruit.dto.admin.SystemHealthResponse;
+import com.eaa.recruit.dto.admin.SystemHealthResponse.Status;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ConsumerGroupListing;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
- * FR-38: System health — DB pool, Redis, Kafka, uptime.
+ * FR-38: System health — DB pool, Redis hit/miss, Kafka consumer lag, uptime.
  */
 @Service
 public class SystemHealthService {
 
     private static final Logger log = LoggerFactory.getLogger(SystemHealthService.class);
 
-    private final HikariDataSource         dataSource;
+    // Thresholds — bump via config if they prove noisy in prod.
+    private static final double POOL_WARN_RATIO      = 0.75;   // >75% connections used
+    private static final double POOL_CRIT_RATIO      = 0.95;
+    private static final double REDIS_WARN_HIT_RATIO = 0.70;   // <70% hits
+    private static final double REDIS_CRIT_HIT_RATIO = 0.30;
+    private static final long   KAFKA_WARN_LAG       = 1_000;
+    private static final long   KAFKA_CRIT_LAG       = 10_000;
+    private static final long   KAFKA_ADMIN_TIMEOUT_SECS = 3;
+
+    private final HikariDataSource              dataSource;
     private final RedisTemplate<String, String> redisTemplate;
-    private final AdminClient              kafkaAdminClient;
+    private final AdminClient                   kafkaAdminClient;
 
     public SystemHealthService(HikariDataSource dataSource,
                                 RedisTemplate<String, String> redisTemplate,
@@ -33,53 +57,165 @@ public class SystemHealthService {
     }
 
     public SystemHealthResponse getHealth() {
-        return new SystemHealthResponse(
-                dbHealth(),
-                redisHealth(),
-                kafkaHealth(),
-                uptimeSeconds());
+        SystemHealthResponse.DatabaseHealth db    = dbHealth();
+        SystemHealthResponse.RedisHealth    redis = redisHealth();
+        SystemHealthResponse.KafkaHealth    kafka = kafkaHealth();
+        long uptime = uptimeSeconds();
+
+        Status overall = worst(db.status(), redis.status(), kafka.status());
+
+        return new SystemHealthResponse(overall, db, redis, kafka, uptime);
     }
+
+    // ── Database ──────────────────────────────────────────────────────────────
 
     private SystemHealthResponse.DatabaseHealth dbHealth() {
         try {
-            var pool = dataSource.getHikariPoolMXBean();
-            return new SystemHealthResponse.DatabaseHealth(
-                    true,
-                    pool.getActiveConnections(),
-                    pool.getIdleConnections());
+            HikariPoolMXBean pool = dataSource.getHikariPoolMXBean();
+            int active = pool.getActiveConnections();
+            int idle   = pool.getIdleConnections();
+            int total  = pool.getTotalConnections();
+            int max    = dataSource.getMaximumPoolSize();
+
+            double usage = max == 0 ? 0 : (double) active / max;
+            Status status = usage >= POOL_CRIT_RATIO ? Status.CRITICAL
+                          : usage >= POOL_WARN_RATIO ? Status.WARNING
+                          : Status.OK;
+
+            return new SystemHealthResponse.DatabaseHealth(status, true, active, idle, total, max);
         } catch (Exception e) {
             log.warn("DB health check failed: {}", e.getMessage());
-            return new SystemHealthResponse.DatabaseHealth(false, 0, 0);
+            return new SystemHealthResponse.DatabaseHealth(Status.CRITICAL, false, 0, 0, 0, 0);
         }
     }
+
+    // ── Redis ────────────────────────────────────────────────────────────────
 
     private SystemHealthResponse.RedisHealth redisHealth() {
         try {
-            Properties info = redisTemplate.getConnectionFactory()
+            Properties stats = redisTemplate.getConnectionFactory()
                     .getConnection()
                     .serverCommands()
-                    .info("server");
-            String version = info != null ? info.getProperty("redis_version", "unknown") : "unknown";
-            return new SystemHealthResponse.RedisHealth(true, "redis_version=" + version);
+                    .info("stats");
+
+            if (stats == null) {
+                return new SystemHealthResponse.RedisHealth(Status.WARNING, true, null, null, null, "stats unavailable");
+            }
+
+            Long hits   = parseLong(stats.getProperty("keyspace_hits"));
+            Long misses = parseLong(stats.getProperty("keyspace_misses"));
+            Double ratio = null;
+            Status status = Status.OK;
+            if (hits != null && misses != null) {
+                long total = hits + misses;
+                if (total > 0) {
+                    ratio = (double) hits / total;
+                    status = ratio < REDIS_CRIT_HIT_RATIO ? Status.CRITICAL
+                           : ratio < REDIS_WARN_HIT_RATIO ? Status.WARNING
+                           : Status.OK;
+                }
+            }
+
+            return new SystemHealthResponse.RedisHealth(status, true, hits, misses, ratio,
+                    "hits=" + hits + " misses=" + misses);
         } catch (Exception e) {
             log.warn("Redis health check failed: {}", e.getMessage());
-            return new SystemHealthResponse.RedisHealth(false, e.getMessage());
+            return new SystemHealthResponse.RedisHealth(Status.CRITICAL, false, null, null, null, e.getMessage());
         }
     }
+
+    // ── Kafka ────────────────────────────────────────────────────────────────
 
     private SystemHealthResponse.KafkaHealth kafkaHealth() {
         try {
-            var nodes = kafkaAdminClient.describeCluster()
+            int brokerCount = kafkaAdminClient.describeCluster()
                     .nodes()
-                    .get(5, TimeUnit.SECONDS);
-            return new SystemHealthResponse.KafkaHealth(true, "brokers=" + nodes.size());
+                    .get(KAFKA_ADMIN_TIMEOUT_SECS, TimeUnit.SECONDS)
+                    .size();
+
+            List<SystemHealthResponse.KafkaHealth.TopicLag> topicLags = computeConsumerLag();
+            long totalLag = topicLags.stream().mapToLong(SystemHealthResponse.KafkaHealth.TopicLag::total).sum();
+
+            Status status = totalLag >= KAFKA_CRIT_LAG ? Status.CRITICAL
+                          : totalLag >= KAFKA_WARN_LAG ? Status.WARNING
+                          : Status.OK;
+
+            return new SystemHealthResponse.KafkaHealth(status, true, brokerCount, totalLag, topicLags,
+                    "brokers=" + brokerCount);
         } catch (Exception e) {
             log.warn("Kafka health check failed: {}", e.getMessage());
-            return new SystemHealthResponse.KafkaHealth(false, e.getMessage());
+            return new SystemHealthResponse.KafkaHealth(Status.CRITICAL, false, 0, 0L, List.of(), e.getMessage());
         }
     }
 
+    private List<SystemHealthResponse.KafkaHealth.TopicLag> computeConsumerLag() throws Exception {
+        Collection<ConsumerGroupListing> groups = kafkaAdminClient.listConsumerGroups()
+                .all().get(KAFKA_ADMIN_TIMEOUT_SECS, TimeUnit.SECONDS);
+
+        if (groups.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> groupIds = groups.stream().map(ConsumerGroupListing::groupId).toList();
+
+        Map<String, ListConsumerGroupOffsetsSpec> offsetSpecs = groupIds.stream()
+                .collect(Collectors.toMap(g -> g, g -> new ListConsumerGroupOffsetsSpec()));
+
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> committed =
+                kafkaAdminClient.listConsumerGroupOffsets(offsetSpecs)
+                        .all().get(KAFKA_ADMIN_TIMEOUT_SECS, TimeUnit.SECONDS);
+
+        // Dedup partition set across all groups for a single endOffsets round-trip
+        Map<TopicPartition, OffsetSpec> endSpec = new HashMap<>();
+        committed.values().forEach(map -> map.keySet().forEach(tp -> endSpec.put(tp, OffsetSpec.latest())));
+
+        if (endSpec.isEmpty()) return List.of();
+
+        Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> endOffsets =
+                kafkaAdminClient.listOffsets(endSpec)
+                        .all().get(KAFKA_ADMIN_TIMEOUT_SECS, TimeUnit.SECONDS);
+
+        List<SystemHealthResponse.KafkaHealth.TopicLag> result = new ArrayList<>();
+        for (Map.Entry<String, Map<TopicPartition, OffsetAndMetadata>> entry : committed.entrySet()) {
+            String group = entry.getKey();
+            Map<String, Map<Integer, Long>> perTopic = new LinkedHashMap<>();
+
+            for (Map.Entry<TopicPartition, OffsetAndMetadata> e : entry.getValue().entrySet()) {
+                TopicPartition tp = e.getKey();
+                long committedOffset = e.getValue() == null ? 0 : e.getValue().offset();
+                long endOffset = endOffsets.containsKey(tp) ? endOffsets.get(tp).offset() : committedOffset;
+                long lag = Math.max(0, endOffset - committedOffset);
+                perTopic.computeIfAbsent(tp.topic(), k -> new LinkedHashMap<>())
+                        .put(tp.partition(), lag);
+            }
+
+            for (Map.Entry<String, Map<Integer, Long>> topicEntry : perTopic.entrySet()) {
+                long total = topicEntry.getValue().values().stream().mapToLong(Long::longValue).sum();
+                result.add(new SystemHealthResponse.KafkaHealth.TopicLag(
+                        topicEntry.getKey(), group, topicEntry.getValue(), total));
+            }
+        }
+        return result;
+    }
+
+    // ── Misc ─────────────────────────────────────────────────────────────────
+
     private long uptimeSeconds() {
         return ManagementFactory.getRuntimeMXBean().getUptime() / 1000;
+    }
+
+    private static Status worst(Status... statuses) {
+        Status worst = Status.OK;
+        for (Status s : statuses) {
+            if (s == Status.CRITICAL) return Status.CRITICAL;
+            if (s == Status.WARNING)  worst = Status.WARNING;
+        }
+        return worst;
+    }
+
+    private static Long parseLong(String value) {
+        if (value == null) return null;
+        try { return Long.parseLong(value.trim()); }
+        catch (NumberFormatException e) { return null; }
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/service/UserStatusService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/UserStatusService.java
@@ -19,11 +19,14 @@ public class UserStatusService {
 
     private final UserRepository          userRepository;
     private final BlockedUserCacheService blockedUserCache;
+    private final AuditLogService         auditLogService;
 
     public UserStatusService(UserRepository userRepository,
-                             BlockedUserCacheService blockedUserCache) {
+                             BlockedUserCacheService blockedUserCache,
+                             AuditLogService auditLogService) {
         this.userRepository   = userRepository;
         this.blockedUserCache = blockedUserCache;
+        this.auditLogService  = auditLogService;
     }
 
     /**
@@ -50,6 +53,7 @@ public class UserStatusService {
             throw new BusinessException("Admins cannot modify Super Admin accounts");
         }
 
+        String oldStatus = target.isActive() ? "ACTIVE" : "INACTIVE";
         if (active) {
             target.activate();
             blockedUserCache.unblock(targetId);
@@ -58,6 +62,13 @@ public class UserStatusService {
             target.deactivate();
             blockedUserCache.block(targetId);
             log.info("User id={} deactivated by admin id={}", targetId, requester.id());
+        }
+
+        String newStatus = active ? "ACTIVE" : "INACTIVE";
+        if (!oldStatus.equals(newStatus)) {
+            auditLogService.log("USER", targetId, oldStatus, newStatus,
+                    userRepository.getReferenceById(requester.id()),
+                    active ? "Admin activated user" : "Admin deactivated user");
         }
     }
 }

--- a/backend/src/test/java/com/eaa/recruit/controller/AdminUserControllerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/controller/AdminUserControllerTest.java
@@ -82,7 +82,7 @@ class AdminUserControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void admin_returns201_onSuccess() throws Exception {
-        when(recruiterAdminService.createRecruiter(any()))
+        when(recruiterAdminService.createRecruiter(any(), any()))
                 .thenReturn(new RecruiterCreatedResponse(
                         5L, "bob@example.com", "Bob Jones",
                         "Recruiter account created successfully"));
@@ -99,7 +99,7 @@ class AdminUserControllerTest {
     @Test
     @WithMockUser(roles = "SUPER_ADMIN")
     void superAdmin_returns201_onSuccess() throws Exception {
-        when(recruiterAdminService.createRecruiter(any()))
+        when(recruiterAdminService.createRecruiter(any(), any()))
                 .thenReturn(new RecruiterCreatedResponse(
                         6L, "bob2@example.com", "Bob Two",
                         "Recruiter account created successfully"));
@@ -118,7 +118,7 @@ class AdminUserControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void admin_returns409_onDuplicateEmail() throws Exception {
-        when(recruiterAdminService.createRecruiter(any()))
+        when(recruiterAdminService.createRecruiter(any(), any()))
                 .thenThrow(new ConflictException("Email is already registered: bob@example.com"));
 
         mockMvc.perform(post("/api/v1/admin/users/recruiter")

--- a/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
@@ -37,6 +37,7 @@ class ApplicationServiceTest {
     @Mock KafkaEventPublisher      kafkaEventPublisher;
     @Mock HardFilterService        hardFilterService;
     @Mock WeightedScoringService   weightedScoringService;
+    @Mock AuditLogService          auditLogService;
 
     ApplicationService service;
 
@@ -47,7 +48,7 @@ class ApplicationServiceTest {
     void setUp() {
         service = new ApplicationService(applicationRepository, jobPostingRepository,
                 userRepository, fileStorageService, kafkaEventPublisher,
-                hardFilterService, weightedScoringService);
+                hardFilterService, weightedScoringService, auditLogService);
     }
 
     private static User candidateUser() {

--- a/backend/src/test/java/com/eaa/recruit/service/ExamServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ExamServiceTest.java
@@ -39,6 +39,8 @@ class ExamServiceTest {
     @Mock ApplicationRepository     applicationRepository;
     @Mock CandidateNotificationPort candidateNotificationPort;
     @Mock KafkaEventPublisher       kafkaEventPublisher;
+    @Mock AuditLogService           auditLogService;
+    @Mock com.eaa.recruit.repository.UserRepository userRepository;
 
     ExamService service;
 
@@ -48,7 +50,8 @@ class ExamServiceTest {
     @BeforeEach
     void setUp() {
         service = new ExamService(examRepository, jobPostingRepository, applicationRepository,
-                candidateNotificationPort, kafkaEventPublisher, new ObjectMapper());
+                candidateNotificationPort, kafkaEventPublisher, new ObjectMapper(),
+                auditLogService, userRepository);
     }
 
     private static JobPosting job(User recruiter) {

--- a/backend/src/test/java/com/eaa/recruit/service/HardFilterServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/HardFilterServiceTest.java
@@ -21,12 +21,13 @@ class HardFilterServiceTest {
 
     @Mock ApplicationRepository       applicationRepository;
     @Mock CandidateNotificationPort   candidateNotificationPort;
+    @Mock AuditLogService             auditLogService;
 
     HardFilterService service;
 
     @BeforeEach
     void setUp() {
-        service = new HardFilterService(applicationRepository, candidateNotificationPort);
+        service = new HardFilterService(applicationRepository, candidateNotificationPort, auditLogService);
     }
 
     private static User candidateWithProfile(Integer heightCm, Integer weightKg, String degree) {

--- a/backend/src/test/java/com/eaa/recruit/service/RecruiterAdminServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/RecruiterAdminServiceTest.java
@@ -7,6 +7,7 @@ import com.eaa.recruit.entity.User;
 import com.eaa.recruit.exception.ConflictException;
 import com.eaa.recruit.notification.WelcomeNotificationPort;
 import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,12 +28,16 @@ class RecruiterAdminServiceTest {
     @Mock UserRepository          userRepository;
     @Mock PasswordEncoder         passwordEncoder;
     @Mock WelcomeNotificationPort welcomeNotification;
+    @Mock AuditLogService         auditLogService;
 
     RecruiterAdminService service;
 
+    private static final AuthenticatedUser ADMIN =
+            new AuthenticatedUser(7L, "admin@eaa.com", "ADMIN");
+
     @BeforeEach
     void setUp() {
-        service = new RecruiterAdminService(userRepository, passwordEncoder, welcomeNotification);
+        service = new RecruiterAdminService(userRepository, passwordEncoder, welcomeNotification, auditLogService);
     }
 
     private static CreateRecruiterRequest validRequest() {
@@ -51,7 +56,7 @@ class RecruiterAdminServiceTest {
         when(passwordEncoder.encode("TempPass1!")).thenReturn("$2a$hashed");
         when(userRepository.save(any(User.class))).thenReturn(savedRecruiter());
 
-        RecruiterCreatedResponse resp = service.createRecruiter(validRequest());
+        RecruiterCreatedResponse resp = service.createRecruiter(validRequest(), ADMIN);
 
         assertThat(resp.email()).isEqualTo("bob@example.com");
         assertThat(resp.fullName()).isEqualTo("Bob Jones");
@@ -69,7 +74,7 @@ class RecruiterAdminServiceTest {
     void createRecruiter_throwsConflict_onDuplicateEmail() {
         when(userRepository.existsByEmail("bob@example.com")).thenReturn(true);
 
-        assertThatThrownBy(() -> service.createRecruiter(validRequest()))
+        assertThatThrownBy(() -> service.createRecruiter(validRequest(), ADMIN))
                 .isInstanceOf(ConflictException.class)
                 .hasMessageContaining("already registered");
 
@@ -86,7 +91,7 @@ class RecruiterAdminServiceTest {
                 .when(welcomeNotification).sendRecruiterWelcome(anyString(), anyString(), anyString());
 
         // Should not throw — notification failure is non-fatal
-        RecruiterCreatedResponse resp = service.createRecruiter(validRequest());
+        RecruiterCreatedResponse resp = service.createRecruiter(validRequest(), ADMIN);
         assertThat(resp.email()).isEqualTo("bob@example.com");
     }
 
@@ -96,7 +101,7 @@ class RecruiterAdminServiceTest {
         when(passwordEncoder.encode("TempPass1!")).thenReturn("$2a$10$bcrypt");
         when(userRepository.save(any())).thenReturn(savedRecruiter());
 
-        service.createRecruiter(validRequest());
+        service.createRecruiter(validRequest(), ADMIN);
 
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(captor.capture());

--- a/backend/src/test/java/com/eaa/recruit/service/ShortlistServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ShortlistServiceTest.java
@@ -6,6 +6,8 @@ import com.eaa.recruit.entity.*;
 import com.eaa.recruit.exception.ResourceNotFoundException;
 import com.eaa.recruit.notification.CandidateNotificationPort;
 import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,12 +28,18 @@ class ShortlistServiceTest {
 
     @Mock ApplicationRepository     applicationRepository;
     @Mock CandidateNotificationPort candidateNotificationPort;
+    @Mock AuditLogService           auditLogService;
+    @Mock UserRepository            userRepository;
 
     ShortlistService service;
 
+    private static final AuthenticatedUser RECRUITER =
+            new AuthenticatedUser(42L, "r@eaa.com", "RECRUITER");
+
     @BeforeEach
     void setUp() {
-        service = new ShortlistService(applicationRepository, candidateNotificationPort);
+        service = new ShortlistService(applicationRepository, candidateNotificationPort,
+                auditLogService, userRepository);
     }
 
     private Application makeExamCompletedApp(Long fakeId) {
@@ -53,7 +61,7 @@ class ShortlistServiceTest {
         when(applicationRepository.findById(1L)).thenReturn(Optional.of(app));
         when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        ShortlistResponse response = service.shortlist(new ShortlistRequest(List.of(1L)));
+        ShortlistResponse response = service.shortlist(new ShortlistRequest(List.of(1L)), RECRUITER);
 
         assertThat(response.shortlisted()).isEqualTo(1);
         assertThat(response.skipped()).isEqualTo(0);
@@ -71,7 +79,7 @@ class ShortlistServiceTest {
 
         when(applicationRepository.findById(1L)).thenReturn(Optional.of(app));
 
-        ShortlistResponse response = service.shortlist(new ShortlistRequest(List.of(1L)));
+        ShortlistResponse response = service.shortlist(new ShortlistRequest(List.of(1L)), RECRUITER);
 
         assertThat(response.shortlisted()).isEqualTo(0);
         assertThat(response.skipped()).isEqualTo(1);
@@ -82,7 +90,7 @@ class ShortlistServiceTest {
     void shortlist_throwsResourceNotFoundException_whenNotFound() {
         when(applicationRepository.findById(99L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.shortlist(new ShortlistRequest(List.of(99L))))
+        assertThatThrownBy(() -> service.shortlist(new ShortlistRequest(List.of(99L)), RECRUITER))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 }

--- a/backend/src/test/java/com/eaa/recruit/service/UserStatusServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/UserStatusServiceTest.java
@@ -24,6 +24,7 @@ class UserStatusServiceTest {
 
     @Mock UserRepository          userRepository;
     @Mock BlockedUserCacheService blockedUserCache;
+    @Mock AuditLogService         auditLogService;
 
     UserStatusService service;
 
@@ -32,7 +33,7 @@ class UserStatusServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new UserStatusService(userRepository, blockedUserCache);
+        service = new UserStatusService(userRepository, blockedUserCache, auditLogService);
     }
 
     private User activeCandidate(Long id) {


### PR DESCRIPTION
## Summary
- **FR-37 Audit log service** — `AuditLog` marked `@Immutable`; status transitions in `ApplicationService`, `HardFilterService`, `ExamService`, `ShortlistService`, `SlotBookingService`, and admin actions in `UserStatusService` + `RecruiterAdminService` now emit audit records. New `GET /api/v1/admin/audit-logs` with filters (entityType, entityId, actorId, from, to) and pagination via `JpaSpecificationExecutor` + `AuditLogSpecifications`.
- **FR-38 System health API** — `GET /api/v1/admin/system-health` (renamed from `/system/health`) returns real Kafka consumer lag per topic (via `AdminClient.listConsumerGroupOffsets` + `listOffsets`), Redis hit/miss ratio (from `INFO stats`), DB pool active/idle/max (Hikari MX), uptime. Status flags OK/WARNING/CRITICAL per-component + overall. `CacheControl.noStore()` — never cached. `@IsAdmin`.
- Closes #128, #129.

## Notes
- Stacked on `feat/fr-27-exam-score-ingestion` (PR #172) because audit hooks call `recordExamScore(double, double, Instant)` and tests use the FR-27 `ExamScoreCallbackRequest.completedAt` field. Rebase onto `main` after #172 merges.

## Test plan
- [ ] `./gradlew test --tests AuditLogServiceTest`
- [ ] POST exam score → verify audit row with `entityType=APPLICATION`, old/new status
- [ ] Deactivate user → verify `entityType=USER`, actor set to admin
- [ ] `GET /api/v1/admin/audit-logs?entityType=APPLICATION&from=...` returns paged filtered results
- [ ] `GET /api/v1/admin/system-health` returns non-null kafka/redis/db/uptime with per-component status
- [ ] Verify `Cache-Control: no-store` header on health response
- [ ] 403 for non-admin on both endpoints

