### PR TITLE
feat(backend): AI model metadata versioning API (FR-39)

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/AdminSystemController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AdminSystemController.java
@@ -2,7 +2,7 @@ package com.eaa.recruit.controller;
 
 import com.eaa.recruit.dto.ApiResponse;
 import com.eaa.recruit.dto.admin.AiModelRequest;
-import com.eaa.recruit.dto.admin.AiModelResponse;
+import com.eaa.recruit.dto.admin.AiModelStateResponse;
 import com.eaa.recruit.dto.admin.AuditLogResponse;
 import com.eaa.recruit.dto.admin.SystemHealthResponse;
 import com.eaa.recruit.entity.AuditLog;
@@ -117,36 +117,22 @@ public class AdminSystemController {
                 .body(ApiResponse.success(systemHealthService.getHealth()));
     }
 
-    /** POST /api/v1/admin/ai-models — FR-39 */
+    /** PUT /api/v1/admin/ai-model — FR-39: register new version + set active. */
     @IsSuperAdmin
-    @PostMapping("/ai-models")
-    public ResponseEntity<ApiResponse<AiModelResponse>> registerModel(
+    @PutMapping("/ai-model")
+    public ResponseEntity<ApiResponse<AiModelStateResponse>> updateModel(
             @Valid @RequestBody AiModelRequest request,
             @AuthenticationPrincipal AuthenticatedUser principal) {
 
-        AiModelResponse response = aiModelService.register(request, principal);
-        return ResponseEntity.ok(ApiResponse.success("AI model registered", response));
+        AiModelStateResponse response = aiModelService.update(request, principal);
+        return ResponseEntity.ok(ApiResponse.success("Active AI model updated", response));
     }
 
-    /** GET /api/v1/admin/ai-models — FR-39 */
+    /** GET /api/v1/admin/ai-model — FR-39: current active + version history. */
     @IsSuperAdmin
-    @GetMapping("/ai-models")
-    public ResponseEntity<ApiResponse<List<AiModelResponse>>> listModels() {
-        return ResponseEntity.ok(ApiResponse.success(aiModelService.listAll()));
-    }
-
-    /** GET /api/v1/admin/ai-models/active — FR-39 */
-    @IsSuperAdmin
-    @GetMapping("/ai-models/active")
-    public ResponseEntity<ApiResponse<AiModelResponse>> getActiveModel() {
-        return ResponseEntity.ok(ApiResponse.success(aiModelService.getActive()));
-    }
-
-    /** POST /api/v1/admin/ai-models/{id}/activate — FR-39 */
-    @IsSuperAdmin
-    @PostMapping("/ai-models/{id}/activate")
-    public ResponseEntity<ApiResponse<AiModelResponse>> activateModel(@PathVariable Long id) {
-        return ResponseEntity.ok(ApiResponse.success("Model activated", aiModelService.activate(id)));
+    @GetMapping("/ai-model")
+    public ResponseEntity<ApiResponse<AiModelStateResponse>> getModel() {
+        return ResponseEntity.ok(ApiResponse.success(aiModelService.getState()));
     }
 
     private AuditLogResponse toResponse(AuditLog log) {

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/AiModelRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/AiModelRequest.java
@@ -2,10 +2,14 @@ package com.eaa.recruit.dto.admin;
 
 import jakarta.validation.constraints.NotBlank;
 
+import java.time.Instant;
+
 public record AiModelRequest(
 
         @NotBlank(message = "modelVersion is required")
         String modelVersion,
 
-        String description
+        String description,
+
+        Instant activatedAt
 ) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/AiModelStateResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/AiModelStateResponse.java
@@ -1,0 +1,8 @@
+package com.eaa.recruit.dto.admin;
+
+import java.util.List;
+
+public record AiModelStateResponse(
+        AiModelResponse current,
+        List<AiModelResponse> history
+) {}

--- a/backend/src/main/java/com/eaa/recruit/entity/AiModelVersion.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/AiModelVersion.java
@@ -38,16 +38,16 @@ public class AiModelVersion {
 
     protected AiModelVersion() {}
 
-    private AiModelVersion(String modelVersion, String description, User createdBy) {
+    private AiModelVersion(String modelVersion, String description, Instant activatedAt, User createdBy) {
         this.modelVersion = modelVersion;
         this.description  = description;
         this.createdBy    = createdBy;
-        this.activatedAt  = Instant.now();
+        this.activatedAt  = activatedAt != null ? activatedAt : Instant.now();
         this.createdAt    = Instant.now();
     }
 
-    public static AiModelVersion create(String modelVersion, String description, User createdBy) {
-        return new AiModelVersion(modelVersion, description, createdBy);
+    public static AiModelVersion create(String modelVersion, String description, Instant activatedAt, User createdBy) {
+        return new AiModelVersion(modelVersion, description, activatedAt, createdBy);
     }
 
     public Long    getId()           { return id; }

--- a/backend/src/main/java/com/eaa/recruit/repository/AiModelVersionRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/AiModelVersionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AiModelVersionRepository extends JpaRepository<AiModelVersion, Long> {
@@ -12,6 +13,8 @@ public interface AiModelVersionRepository extends JpaRepository<AiModelVersion, 
     Optional<AiModelVersion> findByActiveTrue();
 
     boolean existsByModelVersion(String modelVersion);
+
+    List<AiModelVersion> findAllByOrderByCreatedAtDesc();
 
     @Modifying
     @Query("UPDATE AiModelVersion v SET v.active = false WHERE v.active = true")

--- a/backend/src/main/java/com/eaa/recruit/service/AiModelService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/AiModelService.java
@@ -2,9 +2,9 @@ package com.eaa.recruit.service;
 
 import com.eaa.recruit.dto.admin.AiModelRequest;
 import com.eaa.recruit.dto.admin.AiModelResponse;
+import com.eaa.recruit.dto.admin.AiModelStateResponse;
 import com.eaa.recruit.entity.AiModelVersion;
 import com.eaa.recruit.entity.User;
-import com.eaa.recruit.exception.BusinessException;
 import com.eaa.recruit.exception.ConflictException;
 import com.eaa.recruit.exception.ResourceNotFoundException;
 import com.eaa.recruit.repository.AiModelVersionRepository;
@@ -23,55 +23,50 @@ public class AiModelService {
 
     private final AiModelVersionRepository aiModelVersionRepository;
     private final UserRepository            userRepository;
+    private final AuditLogService           auditLogService;
 
     public AiModelService(AiModelVersionRepository aiModelVersionRepository,
-                           UserRepository userRepository) {
+                           UserRepository userRepository,
+                           AuditLogService auditLogService) {
         this.aiModelVersionRepository = aiModelVersionRepository;
         this.userRepository           = userRepository;
+        this.auditLogService          = auditLogService;
     }
 
+    /** FR-39: register new version, set active, audit. */
     @Transactional
-    public AiModelResponse register(AiModelRequest request, AuthenticatedUser principal) {
+    public AiModelStateResponse update(AiModelRequest request, AuthenticatedUser principal) {
         if (aiModelVersionRepository.existsByModelVersion(request.modelVersion())) {
             throw new ConflictException("Model version already registered: " + request.modelVersion());
         }
 
-        User creator = userRepository.findById(principal.id())
+        User actor = userRepository.findById(principal.id())
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
-        AiModelVersion model = AiModelVersion.create(request.modelVersion(), request.description(), creator);
-        model = aiModelVersionRepository.save(model);
-        return toResponse(model);
-    }
+        String previousVersion = aiModelVersionRepository.findByActiveTrue()
+                .map(AiModelVersion::getModelVersion)
+                .orElse(null);
 
-    @Transactional
-    public AiModelResponse activate(Long modelId) {
-        AiModelVersion model = aiModelVersionRepository.findById(modelId)
-                .orElseThrow(() -> new ResourceNotFoundException("Model not found: " + modelId));
-
-        if (model.isActive()) {
-            throw new BusinessException("Model is already active");
-        }
-
-        // Deactivate current active model, then activate new one
         aiModelVersionRepository.deactivateAll();
+
+        AiModelVersion model = AiModelVersion.create(
+                request.modelVersion(), request.description(), request.activatedAt(), actor);
         model.activate();
-        aiModelVersionRepository.save(model);
-        return toResponse(model);
+        model = aiModelVersionRepository.save(model);
+
+        auditLogService.log("AI_MODEL", model.getId(), previousVersion,
+                model.getModelVersion(), actor, "Active model updated");
+
+        return getState();
     }
 
     @Transactional(readOnly = true)
-    public List<AiModelResponse> listAll() {
-        return aiModelVersionRepository.findAll().stream()
-                .map(this::toResponse)
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
-    public AiModelResponse getActive() {
-        return aiModelVersionRepository.findByActiveTrue()
-                .map(this::toResponse)
-                .orElseThrow(() -> new ResourceNotFoundException("No active AI model version found"));
+    public AiModelStateResponse getState() {
+        List<AiModelResponse> history = aiModelVersionRepository.findAllByOrderByCreatedAtDesc()
+                .stream().map(this::toResponse).toList();
+        AiModelResponse current = aiModelVersionRepository.findByActiveTrue()
+                .map(this::toResponse).orElse(null);
+        return new AiModelStateResponse(current, history);
     }
 
     private AiModelResponse toResponse(AiModelVersion m) {

--- a/backend/src/test/java/com/eaa/recruit/service/AiModelServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/AiModelServiceTest.java
@@ -1,0 +1,76 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.admin.AiModelRequest;
+import com.eaa.recruit.dto.admin.AiModelStateResponse;
+import com.eaa.recruit.entity.AiModelVersion;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.repository.AiModelVersionRepository;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AiModelServiceTest {
+
+    @Mock AiModelVersionRepository repository;
+    @Mock UserRepository           userRepository;
+    @Mock AuditLogService          auditLogService;
+
+    AiModelService service;
+
+    private static final AuthenticatedUser SUPER_ADMIN =
+            new AuthenticatedUser(1L, "su@eaa.com", "SUPER_ADMIN");
+
+    @BeforeEach
+    void setUp() {
+        service = new AiModelService(repository, userRepository, auditLogService);
+    }
+
+    @Test
+    void update_activatesNewVersion_andAuditsTransition() {
+        User actor = User.create("su@eaa.com", "hash", Role.SUPER_ADMIN, "Su");
+        AiModelVersion previous = AiModelVersion.create("v1.0", "old", Instant.now(), actor);
+        previous.activate();
+
+        when(repository.existsByModelVersion("v2.0")).thenReturn(false);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(actor));
+        when(repository.findByActiveTrue()).thenReturn(Optional.of(previous));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(repository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(previous));
+
+        AiModelStateResponse response = service.update(
+                new AiModelRequest("v2.0", "new", Instant.now()), SUPER_ADMIN);
+
+        assertThat(response).isNotNull();
+        verify(repository).deactivateAll();
+        verify(auditLogService).log(eq("AI_MODEL"), any(), eq("v1.0"), eq("v2.0"), eq(actor), any());
+    }
+
+    @Test
+    void update_throwsConflict_whenVersionAlreadyExists() {
+        when(repository.existsByModelVersion("v1.0")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.update(
+                new AiModelRequest("v1.0", "dup", null), SUPER_ADMIN))
+                .isInstanceOf(ConflictException.class);
+
+        verify(repository, never()).save(any());
+        verifyNoInteractions(auditLogService);
+    }
+}


### PR DESCRIPTION
## Summary
- `PUT /api/v1/admin/ai-model` — accepts `{modelVersion, description, activatedAt}`, deactivates the previous active model, registers + activates the new one, emits an `AI_MODEL` audit log entry capturing the version transition.
- `GET /api/v1/admin/ai-model` — returns `{ current, history[] }` (history newest-first).
- Super Admin only via `@IsSuperAdmin`.
- Closes #130 (alias #39).

## Notes
- Stacked on `feat/fr-37-38-audit-and-health` (PR #173) for `AuditLogService`. Rebase onto `main` once #173 lands.
- Removed redundant `POST /ai-models`, `GET /ai-models`, `GET /ai-models/active`, `POST /ai-models/{id}/activate` — collapsed into the AC-mandated `PUT/GET /ai-model` pair.

## Test plan
- [ ] `./gradlew test --tests AiModelServiceTest`
- [ ] PUT new version → previous active row flipped to `is_active=false`, new row active
- [ ] GET returns current + history sorted newest-first
- [ ] Audit log row written with `entity_type=AI_MODEL`, old/new versions
- [ ] 403 for non-super-admin