### PR TITLE
infra: Docker Compose for single-command project startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy to .env and adjust as needed. docker-compose reads this automatically.
+
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=recruitment
+
+JWT_SECRET=dev-jwt-secret-change-me-min-256-bits-long-secret-key-12345
+INTERNAL_API_KEY=dev-internal-key

--- a/ai-service/.dockerignore
+++ b/ai-service/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+**/__pycache__/
+*.pyc
+.pytest_cache/
+.venv/
+venv/
+tests/
+*.log

--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim AS runtime
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ src/
+
+RUN useradd -m app && chown -R app:app /app
+USER app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+.gradle/
+build/
+.idea/
+.claude/
+*.iml
+src/test/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+# ── Build stage ──────────────────────────────────────────────────────────────
+FROM eclipse-temurin:23-jdk-alpine AS build
+WORKDIR /workspace
+
+COPY gradle/ gradle/
+COPY gradlew gradle.properties settings.gradle build.gradle ./
+RUN chmod +x gradlew && ./gradlew --version --no-daemon
+
+COPY src/ src/
+RUN ./gradlew bootJar --no-daemon -x test
+
+# ── Runtime stage ────────────────────────────────────────────────────────────
+FROM eclipse-temurin:23-jre-alpine AS runtime
+WORKDIR /app
+
+RUN addgroup -S app && adduser -S app -G app
+COPY --from=build /workspace/build/libs/*.jar app.jar
+
+USER app
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,121 @@
+name: eaa-recruit
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: eaa-postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-recruitment}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-recruitment}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    container_name: eaa-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  kafka:
+    image: bitnami/kafka:3.7
+    container_name: eaa-kafka
+    environment:
+      KAFKA_CFG_NODE_ID: "0"
+      KAFKA_CFG_PROCESS_ROLES: "controller,broker"
+      KAFKA_CFG_LISTENERS: "PLAINTEXT://:9092,CONTROLLER://:9093"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka:9093"
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+    ports:
+      - "9092:9092"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/bitnami/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  backend:
+    build:
+      context: ./backend
+    container_name: eaa-backend
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-recruitment}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-postgres}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret-change-me-min-256-bits-long-secret-key-12345}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY:-dev-internal-key}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+
+  ai-service:
+    build:
+      context: ./ai-service
+    container_name: eaa-ai-service
+    environment:
+      REDIS_URL: redis://redis:6379
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      SPRING_CALLBACK_URL: http://backend:8080
+    depends_on:
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+
+  exam-engine:
+    build:
+      context: ./exam-engine
+    container_name: eaa-exam-engine
+    environment:
+      PORT: "8090"
+      REDIS_ADDR: redis:6379
+      KAFKA_BROKER: kafka:9092
+      SPRING_BASE_URL: http://backend:8080
+      AI_GRADING_URL: http://ai-service:8000
+    depends_on:
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8090:8090"
+
+  frontend:
+    build:
+      context: ./frontend
+    container_name: eaa-frontend
+    depends_on:
+      - backend
+    ports:
+      - "5173:80"
+
+volumes:
+  pgdata:

--- a/exam-engine/.dockerignore
+++ b/exam-engine/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+*.test
+*.out

--- a/exam-engine/Dockerfile
+++ b/exam-engine/Dockerfile
@@ -1,0 +1,21 @@
+# ── Build stage ──────────────────────────────────────────────────────────────
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/exam-engine ./cmd/server
+
+# ── Runtime stage ────────────────────────────────────────────────────────────
+FROM alpine:3.20 AS runtime
+WORKDIR /app
+
+RUN addgroup -S app && adduser -S app -G app && apk add --no-cache ca-certificates
+COPY --from=build /out/exam-engine /app/exam-engine
+
+USER app
+EXPOSE 8090
+
+ENTRYPOINT ["/app/exam-engine"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.vite/
+.idea/
+.vscode/
+*.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+# ── Build stage ──────────────────────────────────────────────────────────────
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ── Runtime stage ────────────────────────────────────────────────────────────
+FROM nginx:1.27-alpine AS runtime
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass         http://backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds production-style multi-stage Dockerfiles for **backend** (Eclipse Temurin 23 JDK build → JRE runtime), **ai-service** (Python 3.11 slim + uvicorn), **exam-engine** (Go 1.23 alpine builder → alpine runtime), and **frontend** (Node 20 builder → `nginx:1.27-alpine`).
- Top-level `docker-compose.yml` brings up Postgres 16, Redis 7, Kafka 3.7 in **KRaft mode** (no Zookeeper), and the four app services with healthcheck-gated `depends_on` so the backend won't start until DB/Redis/Kafka are ready.
- Frontend nginx config proxies `/api/*` to the backend service inside the docker network — SPA avoids CORS without code changes.
- `.env.example` documents tunable secrets (DB creds, JWT, internal API key).

## How to use
```bash
cp .env.example .env   # optional, defaults work for dev
docker compose up --build
```

Service URLs (host-side):
- frontend → http://localhost:5173
- backend  → http://localhost:8080
- ai-service → http://localhost:8000
- exam-engine → http://localhost:8090
- postgres → localhost:5432, redis → localhost:6379, kafka → localhost:9092

## Test plan
- [ ] `docker compose config` validates without errors
- [ ] `docker compose up --build` succeeds; all four app containers reach a running state
- [ ] `curl http://localhost:8080/actuator/health` returns UP
- [ ] `curl http://localhost:8000/health` returns OK from ai-service
- [ ] `curl http://localhost:8090/health` returns OK from exam-engine
- [ ] http://localhost:5173 loads the SPA, and a request to /api/* is proxied to the backend
- [ ] `docker compose down -v` cleans up postgres volume

