### PR TITLE
fix(backend): weighted scoring - round 2dp + fix exam-score ordering [FR-28]

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
@@ -108,6 +108,9 @@ public class ApplicationService {
 
         // FR-22: immediately run hard filter after AI score is recorded
         hardFilterService.applyHardFilter(application);
+
+        // FR-28: recompute weighted final score once hard-filter outcome known
+        weightedScoringService.computeAndPersist(application);
     }
 
     /** FR-27: Receive exam score from Go engine, recompute weighted final score. */
@@ -126,9 +129,9 @@ public class ApplicationService {
             throw new BusinessException("Exam score can only be applied to EXAM_AUTHORIZED applications");
         }
 
-        double finalScore = weightedScoringService.compute(application);
-        application.recordExamScore(request.examScore(), finalScore, request.completedAt());
-        applicationRepository.save(application);
+        // FR-28: examScore must be set on entity BEFORE compute, else exam component = 0
+        application.recordExamScore(request.examScore(), 0.0, request.completedAt());
+        double finalScore = weightedScoringService.computeAndPersist(application);
 
         log.info("Exam score applied applicationId={} examScore={} finalScore={} completedAt={}",
                 applicationId, request.examScore(), finalScore, request.completedAt());

--- a/backend/src/main/java/com/eaa/recruit/service/WeightedScoringService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/WeightedScoringService.java
@@ -46,6 +46,7 @@ public class WeightedScoringService {
                                 ? application.getExamScore() * 0.4 : 0.0);
         double hfComponent   = Boolean.TRUE.equals(hardFilterPassed) ? 100 * 0.2 : 0.0;
 
-        return cvComponent + examComponent + hfComponent;
+        double total = cvComponent + examComponent + hfComponent;
+        return Math.round(total * 100.0) / 100.0;
     }
 }

--- a/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/ApplicationServiceTest.java
@@ -136,8 +136,7 @@ class ApplicationServiceTest {
         app.authorizeExam("token");
 
         when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
-        when(weightedScoringService.compute(app)).thenReturn(72.0);
-        when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(weightedScoringService.computeAndPersist(app)).thenReturn(72.0);
 
         Instant completedAt = Instant.now();
         service.applyExamScore(5L, new ExamScoreCallbackRequest(80.0, completedAt));

--- a/backend/src/test/java/com/eaa/recruit/service/WeightedScoringServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/WeightedScoringServiceTest.java
@@ -59,4 +59,11 @@ class WeightedScoringServiceTest {
         // (0.5 * 100 * 0.4) + (50 * 0.4) + (100 * 0.2) = 20 + 20 + 20 = 60
         assertThat(service.compute(app)).isCloseTo(60.0, offset(0.001));
     }
+
+    @Test
+    void compute_roundsToTwoDecimals() {
+        Application app = makeApp(0.333, 33.33, true);
+        // raw: 13.32 + 13.332 + 20 = 46.652 → round HALF_UP 2dp = 46.65
+        assertThat(service.compute(app)).isEqualTo(46.65);
+    }
 }


### PR DESCRIPTION
## Summary
- Round `WeightedScoringService.compute()` output to 2 decimals (HALF_UP)
- Fix `ApplicationService.applyExamScore` ordering bug: examScore was being set on the entity *after* `compute()` was called, so the exam component silently evaluated to 0 for every exam callback
- Wire `computeAndPersist` into `applyAiScore` so finalScore is recomputed once the hard-filter outcome is known (FR-21 → FR-28)

## Why the ordering fix matters
Previously:
```java
double finalScore = weightedScoringService.compute(application);   // examScore still null
application.recordExamScore(request.examScore(), finalScore, ...); // too late
```
`compute()` read `application.getExamScore()` before it was set, so `examComponent = 0.0` every time. Stored finalScore excluded 40% of the formula.

## Test plan
- [x] `WeightedScoringServiceTest` — existing cases (fullScore / hardFilterFailed / partial) still pass with rounding
- [x] `WeightedScoringServiceTest.compute_roundsToTwoDecimals` — asserts 46.652 → 46.65
- [x] `ApplicationServiceTest.applyExamScore_recordsScoreAndComputesFinalScore` — updated to mock `computeAndPersist` instead of `compute`
- [x] `ApplicationServiceTest.applyExamScore_isIdempotent_whenAlreadyCompleted` — still passes (early-return path untouched)
- [x] Full backend test suite: `gradlew test` green

