### PR TITLE
feat(backend): interview slot booking API [FR-30]

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/SlotBookingController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/SlotBookingController.java
@@ -1,21 +1,21 @@
 package com.eaa.recruit.controller;
 
 import com.eaa.recruit.dto.ApiResponse;
-import com.eaa.recruit.dto.application.SlotBookingRequest;
-import com.eaa.recruit.repository.AvailabilitySlotRepository;
+import com.eaa.recruit.dto.availability.AvailabilitySlotResponse;
 import com.eaa.recruit.security.AuthenticatedUser;
 import com.eaa.recruit.security.rbac.IsCandidate;
 import com.eaa.recruit.service.SlotBookingService;
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
- * FR-30/31: Candidate books an interview slot.
+ * FR-30/31: Candidate lists and books interview slots for a job.
  */
 @RestController
-@RequestMapping("/api/v1/applications")
+@RequestMapping("/api/v1/jobs/{jobId}/slots")
 public class SlotBookingController {
 
     private final SlotBookingService slotBookingService;
@@ -24,15 +24,26 @@ public class SlotBookingController {
         this.slotBookingService = slotBookingService;
     }
 
-    /** POST /api/v1/applications/{id}/book-slot */
+    /** GET /api/v1/jobs/{jobId}/slots — list unbooked slots for the candidate's shortlisted job. */
     @IsCandidate
-    @PostMapping("/{id}/book-slot")
-    public ResponseEntity<ApiResponse<Void>> bookSlot(
-            @PathVariable("id") Long applicationId,
-            @Valid @RequestBody SlotBookingRequest request,
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AvailabilitySlotResponse>>> listAvailable(
+            @PathVariable Long jobId,
             @AuthenticationPrincipal AuthenticatedUser principal) {
 
-        slotBookingService.bookSlot(applicationId, request, principal);
+        List<AvailabilitySlotResponse> slots = slotBookingService.listAvailableForJob(jobId, principal);
+        return ResponseEntity.ok(ApiResponse.success(slots));
+    }
+
+    /** POST /api/v1/jobs/{jobId}/slots/{slotId}/book — book a slot. */
+    @IsCandidate
+    @PostMapping("/{slotId}/book")
+    public ResponseEntity<ApiResponse<Void>> book(
+            @PathVariable Long jobId,
+            @PathVariable Long slotId,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        slotBookingService.bookSlot(jobId, slotId, principal);
         return ResponseEntity.ok(ApiResponse.success("Interview slot booked"));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/dto/application/SlotBookingRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/SlotBookingRequest.java
@@ -1,9 +1,0 @@
-package com.eaa.recruit.dto.application;
-
-import jakarta.validation.constraints.NotNull;
-
-public record SlotBookingRequest(
-
-        @NotNull(message = "slotId is required")
-        Long slotId
-) {}

--- a/backend/src/main/java/com/eaa/recruit/notification/CandidateNotificationPort.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/CandidateNotificationPort.java
@@ -12,4 +12,7 @@ public interface CandidateNotificationPort {
 
     void notifyInterviewReminder(String email, String fullName, String jobTitle,
                                   String slotDate, String startTime);
+
+    void notifyBookingConfirmed(String email, String fullName, String jobTitle,
+                                 String slotDate, String startTime);
 }

--- a/backend/src/main/java/com/eaa/recruit/notification/MockCandidateNotificationAdapter.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/MockCandidateNotificationAdapter.java
@@ -40,4 +40,11 @@ public class MockCandidateNotificationAdapter implements CandidateNotificationPo
         log.info("[MOCK NOTIFY] Interview reminder — to='{}' name='{}' job='{}' date='{}' time='{}'",
                 email, fullName, jobTitle, slotDate, startTime);
     }
+
+    @Override
+    public void notifyBookingConfirmed(String email, String fullName, String jobTitle,
+                                        String slotDate, String startTime) {
+        log.info("[MOCK NOTIFY] Interview booked — to='{}' name='{}' job='{}' date='{}' time='{}'",
+                email, fullName, jobTitle, slotDate, startTime);
+    }
 }

--- a/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
@@ -11,10 +11,13 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
     boolean existsByCandidateIdAndJobId(Long candidateId, Long jobId);
+
+    Optional<Application> findByCandidateIdAndJobId(Long candidateId, Long jobId);
 
     List<Application> findByJobId(Long jobId);
 

--- a/backend/src/main/java/com/eaa/recruit/repository/AvailabilitySlotRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/AvailabilitySlotRepository.java
@@ -26,12 +26,14 @@ public interface AvailabilitySlotRepository extends JpaRepository<AvailabilitySl
                           @Param("startTime")   LocalTime startTime,
                           @Param("endTime")     LocalTime endTime);
 
-    // FR-30: available slots for a job's exam date range
+    // FR-30: available (unbooked) slots owned by a recruiter, from a given date forward
     @Query("""
             SELECT s FROM AvailabilitySlot s
             WHERE s.booked = false
+              AND s.recruiter.id = :recruiterId
               AND s.slotDate >= :fromDate
             ORDER BY s.slotDate ASC, s.startTime ASC
             """)
-    List<AvailabilitySlot> findAvailableSlots(@Param("fromDate") LocalDate fromDate);
+    List<AvailabilitySlot> findAvailableByRecruiterId(@Param("recruiterId") Long recruiterId,
+                                                      @Param("fromDate")    LocalDate fromDate);
 }

--- a/backend/src/main/java/com/eaa/recruit/service/SlotBookingService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/SlotBookingService.java
@@ -1,12 +1,13 @@
 package com.eaa.recruit.service;
 
-import com.eaa.recruit.dto.application.SlotBookingRequest;
+import com.eaa.recruit.dto.availability.AvailabilitySlotResponse;
 import com.eaa.recruit.entity.Application;
 import com.eaa.recruit.entity.ApplicationStatus;
 import com.eaa.recruit.entity.AvailabilitySlot;
 import com.eaa.recruit.exception.BusinessException;
 import com.eaa.recruit.exception.ConflictException;
 import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.notification.CandidateNotificationPort;
 import com.eaa.recruit.repository.ApplicationRepository;
 import com.eaa.recruit.repository.AvailabilitySlotRepository;
 import com.eaa.recruit.security.AuthenticatedUser;
@@ -16,8 +17,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.List;
+
 /**
- * FR-30/31: Candidate books an interview slot.
+ * FR-30/31: Candidate books an interview slot for a job.
  * Double-booking prevented at DB level (unique constraint on booked_by_id)
  * and via optimistic locking (@Version in BaseEntity).
  */
@@ -28,29 +32,52 @@ public class SlotBookingService {
 
     private final ApplicationRepository      applicationRepository;
     private final AvailabilitySlotRepository slotRepository;
+    private final CandidateNotificationPort  candidateNotificationPort;
 
     public SlotBookingService(ApplicationRepository applicationRepository,
-                               AvailabilitySlotRepository slotRepository) {
-        this.applicationRepository = applicationRepository;
-        this.slotRepository        = slotRepository;
+                               AvailabilitySlotRepository slotRepository,
+                               CandidateNotificationPort candidateNotificationPort) {
+        this.applicationRepository     = applicationRepository;
+        this.slotRepository            = slotRepository;
+        this.candidateNotificationPort = candidateNotificationPort;
     }
 
-    @Transactional
-    public void bookSlot(Long applicationId, SlotBookingRequest request,
-                          AuthenticatedUser principal) {
-        Application application = applicationRepository.findById(applicationId)
-                .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
+    /** GET /api/v1/jobs/{jobId}/slots — list available slots for the candidate's shortlisted job. */
+    @Transactional(readOnly = true)
+    public List<AvailabilitySlotResponse> listAvailableForJob(Long jobId, AuthenticatedUser principal) {
+        Application application = requireShortlistedApplication(jobId, principal);
+        Long recruiterId = application.getJob().getCreatedBy().getId();
 
-        if (!application.getCandidate().getId().equals(principal.id())) {
-            throw new BusinessException("You can only book slots for your own applications");
+        return slotRepository.findAvailableByRecruiterId(recruiterId, LocalDate.now()).stream()
+                .map(s -> new AvailabilitySlotResponse(
+                        s.getId(), s.getSlotDate(), s.getStartTime(), s.getEndTime(), false))
+                .toList();
+    }
+
+    /** POST /api/v1/jobs/{jobId}/slots/{slotId}/book — book a slot for the candidate's application. */
+    @Transactional
+    public void bookSlot(Long jobId, Long slotId, AuthenticatedUser principal) {
+        Application application = applicationRepository
+                .findByCandidateIdAndJobId(principal.id(), jobId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No application found for this job"));
+
+        // One booking per job — second attempt returns 409
+        if (application.getStatus() == ApplicationStatus.INTERVIEW_SCHEDULED) {
+            throw new ConflictException("You have already booked an interview slot for this job");
         }
 
         if (application.getStatus() != ApplicationStatus.SHORTLISTED) {
             throw new BusinessException("Interview booking is only allowed for SHORTLISTED applications");
         }
 
-        AvailabilitySlot slot = slotRepository.findById(request.slotId())
-                .orElseThrow(() -> new ResourceNotFoundException("Slot not found: " + request.slotId()));
+        AvailabilitySlot slot = slotRepository.findById(slotId)
+                .orElseThrow(() -> new ResourceNotFoundException("Slot not found: " + slotId));
+
+        // Slot must belong to the job's recruiter
+        if (!slot.getRecruiter().getId().equals(application.getJob().getCreatedBy().getId())) {
+            throw new BusinessException("Slot does not belong to this job's recruiter");
+        }
 
         if (slot.isBooked()) {
             throw new ConflictException("Slot is already booked");
@@ -63,11 +90,32 @@ public class SlotBookingService {
             application.bookInterviewSlot(slot);
             applicationRepository.save(application);
 
-            log.info("Slot booked applicationId={} slotId={} candidateId={}",
-                    applicationId, request.slotId(), principal.id());
+            log.info("Slot booked applicationId={} slotId={} candidateId={} jobId={}",
+                    application.getId(), slotId, principal.id(), jobId);
+
+            candidateNotificationPort.notifyBookingConfirmed(
+                    application.getCandidate().getEmail(),
+                    application.getCandidate().getFullName(),
+                    application.getJob().getTitle(),
+                    slot.getSlotDate().toString(),
+                    slot.getStartTime().toString());
 
         } catch (DataIntegrityViolationException e) {
             throw new ConflictException("Slot was taken concurrently — please choose another");
         }
+    }
+
+    private Application requireShortlistedApplication(Long jobId, AuthenticatedUser principal) {
+        Application application = applicationRepository
+                .findByCandidateIdAndJobId(principal.id(), jobId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No application found for this job"));
+
+        ApplicationStatus status = application.getStatus();
+        if (status != ApplicationStatus.SHORTLISTED && status != ApplicationStatus.INTERVIEW_SCHEDULED) {
+            throw new BusinessException(
+                    "Slot listing is only available for SHORTLISTED or INTERVIEW_SCHEDULED applications");
+        }
+        return application;
     }
 }

--- a/backend/src/test/java/com/eaa/recruit/service/SlotBookingServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/SlotBookingServiceTest.java
@@ -1,0 +1,197 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.availability.AvailabilitySlotResponse;
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ConflictException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.notification.CandidateNotificationPort;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.repository.AvailabilitySlotRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SlotBookingServiceTest {
+
+    @Mock ApplicationRepository       applicationRepository;
+    @Mock AvailabilitySlotRepository  slotRepository;
+    @Mock CandidateNotificationPort   candidateNotificationPort;
+
+    SlotBookingService service;
+
+    private static final AuthenticatedUser CANDIDATE =
+            new AuthenticatedUser(10L, "candidate@eaa.com", "CANDIDATE");
+
+    @BeforeEach
+    void setUp() {
+        service = new SlotBookingService(applicationRepository, slotRepository, candidateNotificationPort);
+    }
+
+    private User recruiter(Long id) {
+        User r = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        setId(r, id);
+        return r;
+    }
+
+    private User candidate() {
+        User c = User.create("candidate@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        setId(c, 10L);
+        return c;
+    }
+
+    private JobPosting job(User rec) {
+        JobPosting j = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now().plusDays(1), LocalDate.now().plusDays(30),
+                LocalDate.now().plusDays(37), rec);
+        setId(j, 1L);
+        return j;
+    }
+
+    private Application shortlisted(User cand, JobPosting j) {
+        Application app = Application.create(cand, j, "cv.pdf");
+        app.applyAiScore(0.9, "url");
+        app.markHardFilterPassed();
+        app.authorizeExam("tok");
+        app.recordExamScore(80.0, 85.0, java.time.Instant.now());
+        app.shortlist();
+        setId(app, 5L);
+        return app;
+    }
+
+    private AvailabilitySlot slot(User rec, Long id, boolean booked) {
+        AvailabilitySlot s = AvailabilitySlot.create(rec, LocalDate.now().plusDays(5),
+                LocalTime.of(10, 0), LocalTime.of(11, 0));
+        setId(s, id);
+        if (booked) s.book(candidate());
+        return s;
+    }
+
+    private static void setId(Object entity, Long id) {
+        try {
+            var f = BaseEntity.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(entity, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void listAvailableForJob_returnsUnbookedSlotsForJobsRecruiter() {
+        User rec = recruiter(7L);
+        JobPosting j = job(rec);
+        Application app = shortlisted(candidate(), j);
+
+        when(applicationRepository.findByCandidateIdAndJobId(10L, 1L)).thenReturn(Optional.of(app));
+        when(slotRepository.findAvailableByRecruiterId(eq(7L), any(LocalDate.class)))
+                .thenReturn(List.of(slot(rec, 100L, false), slot(rec, 101L, false)));
+
+        List<AvailabilitySlotResponse> slots = service.listAvailableForJob(1L, CANDIDATE);
+
+        assertThat(slots).hasSize(2);
+        assertThat(slots).allMatch(s -> !s.booked());
+    }
+
+    @Test
+    void listAvailableForJob_throwsNotFound_whenNoApplicationForJob() {
+        when(applicationRepository.findByCandidateIdAndJobId(10L, 1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.listAvailableForJob(1L, CANDIDATE))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void bookSlot_success_updatesStatusAndNotifies() {
+        User rec = recruiter(7L);
+        JobPosting j = job(rec);
+        Application app = shortlisted(candidate(), j);
+        AvailabilitySlot s = slot(rec, 100L, false);
+
+        when(applicationRepository.findByCandidateIdAndJobId(10L, 1L)).thenReturn(Optional.of(app));
+        when(slotRepository.findById(100L)).thenReturn(Optional.of(s));
+        when(slotRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(applicationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.bookSlot(1L, 100L, CANDIDATE);
+
+        assertThat(app.getStatus()).isEqualTo(ApplicationStatus.INTERVIEW_SCHEDULED);
+        assertThat(s.isBooked()).isTrue();
+        verify(candidateNotificationPort).notifyBookingConfirmed(
+                eq("candidate@eaa.com"), eq("Bob"), eq("Pilot"), anyString(), anyString());
+    }
+
+    @Test
+    void bookSlot_throwsConflict_whenAlreadyInterviewScheduled() {
+        User rec = recruiter(7L);
+        JobPosting j = job(rec);
+        Application app = shortlisted(candidate(), j);
+        app.bookInterviewSlot(slot(rec, 999L, false)); // status → INTERVIEW_SCHEDULED
+
+        when(applicationRepository.findByCandidateIdAndJobId(10L, 1L)).thenReturn(Optional.of(app));
+
+        assertThatThrownBy(() -> service.bookSlot(1L, 100L, CANDIDATE))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("already booked");
+
+        verify(slotRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void bookSlot_throwsBusinessException_whenNotShortlisted() {
+        User rec = recruiter(7L);
+        JobPosting j = job(rec);
+        User cand = candidate();
+        Application app = Application.create(cand, j, "cv.pdf"); // status=SUBMITTED
+        setId(app, 5L);
+
+        when(applicationRepository.findByCandidateIdAndJobId(10L, 1L)).thenReturn(Optional.of(app));
+
+        assertThatThrownBy(() -> service.bookSlot(1L, 100L, CANDIDATE))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void bookSlot_throwsConflict_whenSlotAlreadyBooked() {
+        User rec = recruiter(7L);
+        JobPosting j = job(rec);
+        Application app = shortlisted(candidate(), j);
+        AvailabilitySlot s = slot(rec, 100L, true); // already booked
+
+        when(applicationRepository.findByCandidateIdAndJobId(10L, 1L)).thenReturn(Optional.of(app));
+        when(slotRepository.findById(100L)).thenReturn(Optional.of(s));
+
+        assertThatThrownBy(() -> service.bookSlot(1L, 100L, CANDIDATE))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    void bookSlot_throwsBusinessException_whenSlotBelongsToDifferentRecruiter() {
+        User jobRec   = recruiter(7L);
+        User otherRec = recruiter(99L);
+        JobPosting j  = job(jobRec);
+        Application app = shortlisted(candidate(), j);
+        AvailabilitySlot s = slot(otherRec, 100L, false);
+
+        when(applicationRepository.findByCandidateIdAndJobId(10L, 1L)).thenReturn(Optional.of(app));
+        when(slotRepository.findById(100L)).thenReturn(Optional.of(s));
+
+        assertThatThrownBy(() -> service.bookSlot(1L, 100L, CANDIDATE))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("does not belong");
+    }
+}


### PR DESCRIPTION
Closes #121

## Summary
Implements candidate-facing slot listing + booking against the URL scheme from the issue AC (`/api/v1/jobs/{jobId}/slots` and `/api/v1/jobs/{jobId}/slots/{slotId}/book`). Prior implementation used an application-scoped path (`/api/v1/applications/{id}/book-slot`) and had no list endpoint — both reworked.

## Endpoints
| Method | Path | Role |
|---|---|---|
| `GET`  | `/api/v1/jobs/{jobId}/slots` | CANDIDATE |
| `POST` | `/api/v1/jobs/{jobId}/slots/{slotId}/book` | CANDIDATE |

## Acceptance criteria mapping
- [x] Candidate-only (`@IsCandidate`)
- [x] One booking per job — second attempt returns **409** (status = `INTERVIEW_SCHEDULED`)
- [x] Booked slots excluded from listing (`findAvailableByRecruiterId` filters `booked = false`)
- [x] Status transitions to `INTERVIEW_SCHEDULED` via `Application.bookInterviewSlot`
- [x] Confirmation notification (`notifyBookingConfirmed` added to `CandidateNotificationPort`)

## Also
- Added `ApplicationRepository.findByCandidateIdAndJobId`
- Replaced `findAvailableSlots(fromDate)` with recruiter-scoped `findAvailableByRecruiterId(recruiterId, fromDate)` so the listing only shows slots owned by the job's recruiter
- Slot ownership check: booking rejected if slot does not belong to the job's recruiter
- Deleted unused `SlotBookingRequest` DTO (slotId now path-scoped)

## Tests
`SlotBookingServiceTest` — 7 cases:
- list happy path + 404 when no application
- book happy path (status, slot flag, notification)
- 409 when already scheduled, when slot already booked
- 400 when application not shortlisted, when slot belongs to a different recruiter

All service-layer unit tests pass. Integration tests (Redis/Kafka/Postgres) not run locally — unchanged by this PR.