### PR TITLE
feat(backend): double-booking prevention, interview reminders, feedback report [FR-31/32/34]

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/FeedbackController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/FeedbackController.java
@@ -5,6 +5,7 @@ import com.eaa.recruit.dto.application.DecisionRequest;
 import com.eaa.recruit.dto.application.DecisionResponse;
 import com.eaa.recruit.dto.application.FeedbackReportResponse;
 import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsAuthenticated;
 import com.eaa.recruit.security.rbac.IsCandidate;
 import com.eaa.recruit.security.rbac.IsRecruiter;
 import com.eaa.recruit.service.FeedbackReportService;
@@ -51,8 +52,8 @@ public class FeedbackController {
         return ResponseEntity.ok(ApiResponse.success("Decision recorded", response));
     }
 
-    /** GET /api/v1/applications/{id}/feedback — FR-34 */
-    @IsCandidate
+    /** GET /api/v1/applications/{id}/feedback — FR-34: candidate + recruiter */
+    @IsAuthenticated
     @GetMapping("/{id}/feedback")
     public ResponseEntity<ApiResponse<FeedbackReportResponse>> getFeedback(
             @PathVariable("id") Long applicationId,

--- a/backend/src/main/java/com/eaa/recruit/notification/CandidateNotificationPort.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/CandidateNotificationPort.java
@@ -15,4 +15,7 @@ public interface CandidateNotificationPort {
 
     void notifyBookingConfirmed(String email, String fullName, String jobTitle,
                                  String slotDate, String startTime);
+
+    void notifyRecruiterInterviewReminder(String email, String recruiterName, String jobTitle,
+                                           String candidateName, String slotDate, String startTime);
 }

--- a/backend/src/main/java/com/eaa/recruit/notification/MockCandidateNotificationAdapter.java
+++ b/backend/src/main/java/com/eaa/recruit/notification/MockCandidateNotificationAdapter.java
@@ -47,4 +47,11 @@ public class MockCandidateNotificationAdapter implements CandidateNotificationPo
         log.info("[MOCK NOTIFY] Interview booked — to='{}' name='{}' job='{}' date='{}' time='{}'",
                 email, fullName, jobTitle, slotDate, startTime);
     }
+
+    @Override
+    public void notifyRecruiterInterviewReminder(String email, String recruiterName, String jobTitle,
+                                                  String candidateName, String slotDate, String startTime) {
+        log.info("[MOCK NOTIFY] Interview reminder (recruiter) — to='{}' recruiter='{}' job='{}' candidate='{}' date='{}' time='{}'",
+                email, recruiterName, jobTitle, candidateName, slotDate, startTime);
+    }
 }

--- a/backend/src/main/java/com/eaa/recruit/scheduler/InterviewReminderScheduler.java
+++ b/backend/src/main/java/com/eaa/recruit/scheduler/InterviewReminderScheduler.java
@@ -46,12 +46,21 @@ public class InterviewReminderScheduler {
 
         for (Application application : upcoming) {
             try {
+                String jobTitle    = application.getJob().getTitle();
+                String slotDate    = application.getInterviewSlot().getSlotDate().toString();
+                String startTime   = application.getInterviewSlot().getStartTime().toString();
+
                 candidateNotificationPort.notifyInterviewReminder(
                         application.getCandidate().getEmail(),
                         application.getCandidate().getFullName(),
-                        application.getJob().getTitle(),
-                        application.getInterviewSlot().getSlotDate().toString(),
-                        application.getInterviewSlot().getStartTime().toString());
+                        jobTitle, slotDate, startTime);
+
+                candidateNotificationPort.notifyRecruiterInterviewReminder(
+                        application.getJob().getCreatedBy().getEmail(),
+                        application.getJob().getCreatedBy().getFullName(),
+                        jobTitle,
+                        application.getCandidate().getFullName(),
+                        slotDate, startTime);
 
                 application.markReminderSent();
                 applicationRepository.save(application);

--- a/backend/src/main/java/com/eaa/recruit/security/rbac/IsAuthenticated.java
+++ b/backend/src/main/java/com/eaa/recruit/security/rbac/IsAuthenticated.java
@@ -1,0 +1,11 @@
+package com.eaa.recruit.security.rbac;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import java.lang.annotation.*;
+
+/** Any authenticated user (any role). */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("isAuthenticated()")
+public @interface IsAuthenticated {}

--- a/backend/src/main/java/com/eaa/recruit/service/FeedbackReportService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/FeedbackReportService.java
@@ -10,7 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * FR-34: Candidate views their feedback report.
+ * FR-34: Aggregates stored application data into a feedback report.
+ * Candidates see their own applications; recruiters see any application for their jobs.
  */
 @Service
 public class FeedbackReportService {
@@ -26,12 +27,21 @@ public class FeedbackReportService {
         Application application = applicationRepository.findById(applicationId)
                 .orElseThrow(() -> new ResourceNotFoundException("Application not found: " + applicationId));
 
-        if (!application.getCandidate().getId().equals(principal.id())) {
-            throw new BusinessException("You can only view feedback for your own applications");
+        String role = principal.role();
+
+        if ("CANDIDATE".equals(role)) {
+            if (!application.getCandidate().getId().equals(principal.id())) {
+                throw new BusinessException("You can only view feedback for your own applications");
+            }
+        } else if ("RECRUITER".equals(role)) {
+            if (!application.getJob().getCreatedBy().getId().equals(principal.id())) {
+                throw new BusinessException("You can only view feedback for applications on your jobs");
+            }
         }
 
+        // AC: 404 if no final decision yet
         if (!application.hasFinalDecision()) {
-            throw new BusinessException("Feedback not available until a final decision is made");
+            throw new ResourceNotFoundException("Feedback report not available — no final decision recorded yet");
         }
 
         return new FeedbackReportResponse(
@@ -43,6 +53,7 @@ public class FeedbackReportService {
                 application.getHardFilterPassed(),
                 application.getFinalScore(),
                 application.getXaiReportUrl(),
+                // Candidates see decision notes (it's their own feedback); recruiters see all
                 application.getDecisionNotes());
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/service/SlotBookingService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/SlotBookingService.java
@@ -14,6 +14,7 @@ import com.eaa.recruit.security.AuthenticatedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -100,7 +101,7 @@ public class SlotBookingService {
                     slot.getSlotDate().toString(),
                     slot.getStartTime().toString());
 
-        } catch (DataIntegrityViolationException e) {
+        } catch (DataIntegrityViolationException | ObjectOptimisticLockingFailureException e) {
             throw new ConflictException("Slot was taken concurrently — please choose another");
         }
     }

--- a/backend/src/test/java/com/eaa/recruit/scheduler/InterviewReminderSchedulerTest.java
+++ b/backend/src/test/java/com/eaa/recruit/scheduler/InterviewReminderSchedulerTest.java
@@ -53,6 +53,7 @@ class InterviewReminderSchedulerTest {
         scheduler.sendReminders();
 
         verify(candidateNotificationPort).notifyInterviewReminder(any(), any(), any(), any(), any());
+        verify(candidateNotificationPort).notifyRecruiterInterviewReminder(any(), any(), any(), any(), any(), any());
         verify(applicationRepository).save(app);
     }
 

--- a/backend/src/test/java/com/eaa/recruit/service/FeedbackReportServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/FeedbackReportServiceTest.java
@@ -1,0 +1,141 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.application.FeedbackReportResponse;
+import com.eaa.recruit.entity.*;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.ApplicationRepository;
+import com.eaa.recruit.security.AuthenticatedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeedbackReportServiceTest {
+
+    @Mock ApplicationRepository applicationRepository;
+
+    FeedbackReportService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FeedbackReportService(applicationRepository);
+    }
+
+    private User recruiter(Long id) {
+        User r = User.create("r@eaa.com", "hash", Role.RECRUITER, "Alice");
+        setId(r, id);
+        return r;
+    }
+
+    private Application decidedApp(User rec) {
+        User cand = User.create("c@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        setId(cand, 10L);
+        JobPosting job = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now().plusDays(1), LocalDate.now().plusDays(30),
+                LocalDate.now().plusDays(37), rec);
+        setId(job, 1L);
+        Application app = Application.create(cand, job, "cv.pdf");
+        app.applyAiScore(0.9, "http://xai");
+        app.markHardFilterPassed();
+        app.authorizeExam("tok");
+        app.recordExamScore(80.0, 85.0, Instant.now());
+        app.shortlist();
+        app.recordDecision(ApplicationStatus.SELECTED, "Great candidate", rec);
+        setId(app, 5L);
+        return app;
+    }
+
+    private static void setId(Object entity, Long id) {
+        try {
+            var f = BaseEntity.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(entity, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void getFeedback_candidateSeesOwnApplication() {
+        User rec = recruiter(7L);
+        Application app = decidedApp(rec);
+        AuthenticatedUser candidate = new AuthenticatedUser(10L, "c@eaa.com", "CANDIDATE");
+
+        when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
+
+        FeedbackReportResponse resp = service.getFeedback(5L, candidate);
+
+        assertThat(resp.applicationId()).isEqualTo(5L);
+        assertThat(resp.status()).isEqualTo(ApplicationStatus.SELECTED);
+        assertThat(resp.cvRelevanceScore()).isEqualTo(0.9);
+        assertThat(resp.examScore()).isEqualTo(80.0);
+        assertThat(resp.hardFilterPassed()).isTrue();
+        assertThat(resp.decisionNotes()).isEqualTo("Great candidate");
+    }
+
+    @Test
+    void getFeedback_recruiterSeesApplicationOnOwnJob() {
+        User rec = recruiter(7L);
+        Application app = decidedApp(rec);
+        AuthenticatedUser recruiterPrincipal = new AuthenticatedUser(7L, "r@eaa.com", "RECRUITER");
+
+        when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
+
+        FeedbackReportResponse resp = service.getFeedback(5L, recruiterPrincipal);
+
+        assertThat(resp.jobTitle()).isEqualTo("Pilot");
+    }
+
+    @Test
+    void getFeedback_throws404_whenNoFinalDecision() {
+        User rec = recruiter(7L);
+        User cand = User.create("c@eaa.com", "hash", Role.CANDIDATE, "Bob");
+        setId(cand, 10L);
+        JobPosting job = JobPosting.create("Pilot", "desc", 170, 60, "BSc",
+                LocalDate.now().plusDays(1), LocalDate.now().plusDays(30),
+                LocalDate.now().plusDays(37), rec);
+        Application app = Application.create(cand, job, "cv.pdf");
+        setId(app, 5L);
+
+        when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
+
+        assertThatThrownBy(() -> service.getFeedback(5L, new AuthenticatedUser(10L, "c@eaa.com", "CANDIDATE")))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("no final decision");
+    }
+
+    @Test
+    void getFeedback_throws400_whenCandidateAccessesOtherApplication() {
+        User rec = recruiter(7L);
+        Application app = decidedApp(rec);
+        AuthenticatedUser other = new AuthenticatedUser(99L, "other@eaa.com", "CANDIDATE");
+
+        when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
+
+        assertThatThrownBy(() -> service.getFeedback(5L, other))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void getFeedback_throws400_whenRecruiterAccessesOtherJobApplication() {
+        User rec = recruiter(7L);
+        Application app = decidedApp(rec);
+        AuthenticatedUser otherRecruiter = new AuthenticatedUser(99L, "other@eaa.com", "RECRUITER");
+
+        when(applicationRepository.findById(5L)).thenReturn(Optional.of(app));
+
+        assertThatThrownBy(() -> service.getFeedback(5L, otherRecruiter))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/SlotBookingServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/SlotBookingServiceTest.java
@@ -5,6 +5,7 @@ import com.eaa.recruit.entity.*;
 import com.eaa.recruit.exception.BusinessException;
 import com.eaa.recruit.exception.ConflictException;
 import com.eaa.recruit.exception.ResourceNotFoundException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import com.eaa.recruit.notification.CandidateNotificationPort;
 import com.eaa.recruit.repository.ApplicationRepository;
 import com.eaa.recruit.repository.AvailabilitySlotRepository;
@@ -193,5 +194,21 @@ class SlotBookingServiceTest {
         assertThatThrownBy(() -> service.bookSlot(1L, 100L, CANDIDATE))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("does not belong");
+    }
+
+    @Test
+    void bookSlot_throwsConflict_onOptimisticLockingFailure() {
+        User rec = recruiter(7L);
+        JobPosting j = job(rec);
+        Application app = shortlisted(candidate(), j);
+        AvailabilitySlot s = slot(rec, 100L, false);
+
+        when(applicationRepository.findByCandidateIdAndJobId(10L, 1L)).thenReturn(Optional.of(app));
+        when(slotRepository.findById(100L)).thenReturn(Optional.of(s));
+        when(slotRepository.save(any())).thenThrow(new ObjectOptimisticLockingFailureException("slot", 100L));
+
+        assertThatThrownBy(() -> service.bookSlot(1L, 100L, CANDIDATE))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("concurrently");
     }
 }


### PR DESCRIPTION
Closes #122
Closes #123
Closes #125

## FR-31 — Double-booking prevention
Existing code already had: DB unique constraint (`uq_slot_booked_by`), `@Version` optimistic locking on `BaseEntity`, and `DataIntegrityViolationException` → 409 catch. Gap: `ObjectOptimisticLockingFailureException` (thrown when the ORM detects a stale version before hitting the DB) was unhandled and would surface as 500.

- Added `ObjectOptimisticLockingFailureException` to the catch block alongside `DataIntegrityViolationException`
- New test: `bookSlot_throwsConflict_onOptimisticLockingFailure`

## FR-32 — Interview reminder scheduler
Scheduler was notifying candidates only. AC requires both candidate and recruiter.

- Added `notifyRecruiterInterviewReminder` to `CandidateNotificationPort` + mock adapter
- Scheduler now fires both notifications per application per trigger window
- Test updated to verify `notifyRecruiterInterviewReminder` is called

## FR-34 — Feedback report aggregator
Three gaps vs AC:
1. No-decision path returned HTTP 400 — AC specifies 404. Fixed to `ResourceNotFoundException`.
2. Endpoint was `@IsCandidate` only — AC says recruiter can also view. Added `@IsAuthenticated` + service-level ownership checks (candidate → own application; recruiter → own job's applications).
3. No test existed. Added 5-case `FeedbackReportServiceTest`.

Added `@IsAuthenticated` RBAC annotation (any authenticated role) — reusable by other endpoints that need broad access with service-layer enforcement.

## Tests
All service-layer unit tests pass. Integration tests (Redis/Kafka/Postgres) require running infrastructure — unchanged by this PR.