### PR TITLE
feat(frontend): layout system, interceptors, profile builder & design system [FR-81/82/84]

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,7 @@
  */
 import axios from 'axios'
 import { useAuthStore } from '@/store/authStore'
+import { showToast } from '@/hooks/useToast'
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
 
@@ -26,9 +27,14 @@ apiClient.interceptors.request.use((config) => {
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401) {
+    const status: number | undefined = error.response?.status
+    if (status === 401) {
       useAuthStore.getState().logout()
       window.location.href = '/login'
+    } else if (status !== undefined && status >= 500) {
+      showToast({ title: 'Server error', description: 'Something went wrong. Please try again.', variant: 'error' })
+    } else if (!error.response) {
+      showToast({ title: 'Network error', description: 'Check your connection and try again.', variant: 'error' })
     }
     return Promise.reject(error)
   }

--- a/frontend/src/components/EaaLogo.tsx
+++ b/frontend/src/components/EaaLogo.tsx
@@ -1,0 +1,32 @@
+interface EaaLogoProps {
+  size?: number
+  className?: string
+}
+
+export function EaaLogo({ size = 32, className }: EaaLogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-label="EAA Recruit"
+    >
+      {/* Shield base */}
+      <path
+        d="M16 2L4 7v9c0 6.627 5.148 11.95 12 13 6.852-1.05 12-6.373 12-13V7L16 2z"
+        fill="hsl(207 65% 40%)"
+      />
+      {/* Wing chevron */}
+      <path
+        d="M8 16l8-6 8 6-8 3-8-3z"
+        fill="#c9a84c"
+        opacity="0.9"
+      />
+      {/* Centre fuselage */}
+      <rect x="15" y="10" width="2" height="12" rx="1" fill="white" opacity="0.9" />
+    </svg>
+  )
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { Menu } from 'lucide-react'
 import { useAuthStore } from '@/store/authStore'
 import { Sidebar } from './Sidebar'
 import { Toaster } from '@/components/ui/toaster'
+import { EaaLogo } from '@/components/EaaLogo'
 
 export function AppShell() {
   const { isAuthenticated } = useAuthStore()
@@ -38,6 +39,7 @@ export function AppShell() {
           <button onClick={() => setMobileOpen(true)}>
             <Menu className="h-5 w-5 text-foreground" />
           </button>
+          <EaaLogo size={24} />
           <span className="font-semibold text-foreground">EAA Recruit</span>
         </header>
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,8 +5,9 @@ import type { UserRole } from '@/types/auth'
 import {
   LayoutDashboard, Briefcase, FileText, BookOpen, Calendar,
   Trophy, Users, Activity, ScrollText, BarChart3, Brain,
-  ClipboardList, Settings, LogOut, Plane,
+  ClipboardList, Settings, LogOut,
 } from 'lucide-react'
+import { EaaLogo } from '@/components/EaaLogo'
 
 interface NavItem {
   label: string
@@ -59,9 +60,7 @@ export function Sidebar({ onClose }: SidebarProps) {
     <aside className="flex flex-col h-full bg-card border-r border-border w-64">
       {/* Brand */}
       <div className="flex items-center gap-3 px-6 py-5 border-b border-border">
-        <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center shrink-0">
-          <Plane className="h-4 w-4 text-white" />
-        </div>
+        <EaaLogo size={32} className="shrink-0" />
         <div>
           <p className="font-semibold text-foreground text-sm">EAA Recruit</p>
           <p className="text-xs text-muted-foreground capitalize">{user?.role?.toLowerCase().replace('_', ' ')}</p>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,49 +1,74 @@
+import { Link } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
 import { Card, CardContent } from '@/components/ui/card'
-import { Plane } from 'lucide-react'
+import { EaaLogo } from '@/components/EaaLogo'
+import type { UserRole } from '@/types/auth'
+
+const QUICK_LINKS: Record<UserRole, { label: string; to: string; desc: string }[]> = {
+  CANDIDATE: [
+    { label: 'Browse Jobs',       to: '/jobs',         desc: 'Find open positions' },
+    { label: 'My Applications',   to: '/applications', desc: 'Track your pipeline status' },
+    { label: 'My Exam',           to: '/exam',         desc: 'Take your pending exam' },
+    { label: 'Interview Slot',    to: '/interview',    desc: 'Book or view your slot' },
+    { label: 'Results',           to: '/results',      desc: 'View final decision' },
+    { label: 'Profile',           to: '/profile',      desc: 'Update your details' },
+  ],
+  RECRUITER: [
+    { label: 'Post a Job',        to: '/jobs/new',     desc: 'Create a new job posting' },
+    { label: 'Applications',      to: '/applications', desc: 'Review candidates' },
+    { label: 'Rankings',          to: '/recruiter/rankings', desc: 'Weighted scores & shortlist' },
+    { label: 'Interview Calendar',to: '/availability', desc: 'Manage your availability' },
+  ],
+  ADMIN: [
+    { label: 'User Management',   to: '/admin/users',  desc: 'Create and manage users' },
+    { label: 'System Health',     to: '/admin/health', desc: 'Services and metrics' },
+    { label: 'Audit Logs',        to: '/admin/audit',  desc: 'Full activity trail' },
+    { label: 'Analytics',         to: '/admin/analytics', desc: 'Pipeline export' },
+  ],
+  SUPER_ADMIN: [
+    { label: 'User Management',   to: '/admin/users',     desc: 'Create and manage users' },
+    { label: 'System Health',     to: '/admin/health',    desc: 'Services and metrics' },
+    { label: 'Audit Logs',        to: '/admin/audit',     desc: 'Full activity trail' },
+    { label: 'Analytics',         to: '/admin/analytics', desc: 'Pipeline export' },
+    { label: 'AI Model',          to: '/admin/ai-model',  desc: 'Manage active model version' },
+  ],
+}
+
+function greeting() {
+  const h = new Date().getHours()
+  if (h < 12) return 'Good morning'
+  if (h < 18) return 'Good afternoon'
+  return 'Good evening'
+}
 
 export function DashboardPage() {
   const { user } = useAuthStore()
-
-  const greeting = () => {
-    const h = new Date().getHours()
-    if (h < 12) return 'Good morning'
-    if (h < 18) return 'Good afternoon'
-    return 'Good evening'
-  }
+  const links = user ? (QUICK_LINKS[user.role] ?? []) : []
 
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-4">
-        <div className="w-12 h-12 rounded-full bg-primary flex items-center justify-center shrink-0">
-          <Plane className="h-6 w-6 text-white" />
-        </div>
+        <EaaLogo size={48} />
         <div>
-          <h1 className="text-2xl font-bold">{greeting()}, {user?.fullName?.split(' ')[0]}.</h1>
-          <p className="text-muted-foreground text-sm">Welcome to EAA Recruit.</p>
+          <h1 className="text-2xl font-bold">
+            {greeting()}, {user?.fullName?.split(' ')[0]}.
+          </h1>
+          <p className="text-muted-foreground text-sm capitalize">
+            {user?.role?.toLowerCase().replace('_', ' ')} · EAA Recruit
+          </p>
         </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-        {[
-          { title: 'CV Screening', desc: 'AI-powered relevance scoring via SBERT', icon: '📄' },
-          { title: 'Exam Engine', desc: 'Concurrent batch exam management', icon: '📝' },
-          { title: 'Interview Scheduling', desc: 'Slot booking with conflict prevention', icon: '📅' },
-          { title: 'XAI Feedback', desc: 'Explainable AI reports for candidates', icon: '🔍' },
-          { title: 'Rankings', desc: 'Weighted scoring: CV 40% + Exam 40% + HF 20%', icon: '🏆' },
-          { title: 'Audit Logs', desc: 'Full transparency on every status change', icon: '📋' },
-        ].map((f) => (
-          <Card key={f.title} className="hover:border-primary/50 transition-colors">
-            <CardContent className="pt-5">
-              <div className="flex items-start gap-3">
-                <span className="text-2xl">{f.icon}</span>
-                <div>
-                  <p className="font-medium text-foreground">{f.title}</p>
-                  <p className="text-xs text-muted-foreground mt-0.5">{f.desc}</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+        {links.map((l) => (
+          <Link key={l.to} to={l.to}>
+            <Card className="hover:border-primary/50 transition-colors cursor-pointer h-full">
+              <CardContent className="pt-5">
+                <p className="font-medium text-foreground">{l.label}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{l.desc}</p>
+              </CardContent>
+            </Card>
+          </Link>
         ))}
       </div>
     </div>

--- a/frontend/src/pages/candidate/ProfilePage.tsx
+++ b/frontend/src/pages/candidate/ProfilePage.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { profileApi } from '@/api/profile'
+import { showToast } from '@/hooks/useToast'
 
 const schema = z.object({
   heightCm:       z.coerce.number().min(100).max(250),
@@ -27,12 +28,21 @@ export function ProfilePage() {
   })
 
   useEffect(() => {
-    profileApi.get().then((r) => reset(r.data.data as FormData)).catch(() => {})
+    profileApi.get()
+      .then((r) => reset(r.data.data as FormData))
+      .catch(() => {
+        showToast({ title: 'Could not load profile', description: 'Fill in your details below.', variant: 'warning' })
+      })
   }, [reset])
 
   const onSubmit = async (data: FormData) => {
-    await profileApi.update(data)
-    navigate('/jobs')
+    try {
+      await profileApi.update(data)
+      showToast({ title: 'Profile saved', variant: 'success' })
+      navigate('/jobs')
+    } catch {
+      showToast({ title: 'Save failed', description: 'Please try again.', variant: 'error' })
+    }
   }
 
   const fields: { name: keyof FormData; label: string; type?: string }[] = [


### PR DESCRIPTION
## Summary

- **FR-81**: Axios interceptors — request attaches Bearer token from Zustand; response handles 401 (logout + redirect), 5xx (error toast), and network errors (toast) via \`showToast()\`
- **FR-82**: Role-based layout — \`AppShell\` with responsive desktop sidebar + mobile overlay drawer; \`Sidebar\` with \`NAV_BY_ROLE\` map for CANDIDATE / RECRUITER / ADMIN / SUPER_ADMIN; \`DashboardPage\` shows role-specific quick-link cards
- **FR-84**: Candidate profile builder — Zod form (height, weight, degree, field of study, graduation year); prefills from \`GET /candidates/profile\`; success/error toasts on submit; navigates to /jobs on save
- **chore**: EAA SVG shield logo (sky-blue + gold wing chevron) replaces Plane icon placeholder in sidebar and mobile topbar; design tokens (navy/sky/silver/gold + Shadcn semantic vars) live in \`index.css\`

## Test plan

- [ ] Login as CANDIDATE → sidebar shows candidate nav, dashboard shows candidate quick-links
- [ ] Login as RECRUITER → sidebar shows recruiter nav, dashboard shows recruiter quick-links
- [ ] Login as ADMIN/SUPER_ADMIN → correct admin nav items rendered
- [ ] 401 response → auto-logout + redirect to /login
- [ ] 5xx / network error → error toast appears
- [ ] Profile page prefills saved data; save shows success toast and navigates to /jobs
- [ ] Mobile: hamburger opens sidebar overlay; nav click closes it
- [ ] EAA logo renders in sidebar brand and mobile topbar