### PR TITLE
feat(frontend): job board, application timeline & exam interface [FR-85/86/87]

### DIFF
--- a/frontend/src/pages/candidate/ApplicationsPage.tsx
+++ b/frontend/src/pages/candidate/ApplicationsPage.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react'
-import { CheckCircle2, Circle, Clock, XCircle, AlertCircle } from 'lucide-react'
+import { CheckCircle2, Circle, Clock, XCircle, AlertCircle, Loader2 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { applicationsApi, type Application, type ApplicationStatus } from '@/api/applications'
+import { showToast } from '@/hooks/useToast'
 
 const STAGES: { status: ApplicationStatus[]; label: string }[] = [
-  { status: ['SUBMITTED'],          label: 'Applied' },
-  { status: ['AI_SCREENING'],       label: 'AI Screening' },
-  { status: ['EXAM_AUTHORIZED', 'EXAM_COMPLETED'], label: 'Exam' },
-  { status: ['SHORTLISTED', 'INTERVIEW_SCHEDULED'], label: 'Interview' },
-  { status: ['SELECTED', 'REJECTED', 'WAITLISTED'], label: 'Decision' },
+  { status: ['SUBMITTED'],                              label: 'Applied' },
+  { status: ['AI_SCREENING', 'HARD_FILTER_FAILED'],     label: 'AI Screening' },
+  { status: ['EXAM_AUTHORIZED', 'EXAM_COMPLETED'],      label: 'Exam' },
+  { status: ['SHORTLISTED', 'INTERVIEW_SCHEDULED'],     label: 'Interview' },
+  { status: ['SELECTED', 'REJECTED', 'WAITLISTED'],     label: 'Decision' },
 ]
 
 const STATUS_VARIANT: Record<ApplicationStatus, 'default' | 'success' | 'destructive' | 'warning' | 'secondary' | 'outline'> = {
@@ -39,8 +40,8 @@ function Timeline({ app }: { app: Application }) {
   return (
     <div className="flex items-center gap-0">
       {STAGES.map((stage, i) => {
-        const done    = i < currentStageIdx
-        const current = i === currentStageIdx
+        const done        = i < currentStageIdx
+        const current     = i === currentStageIdx
         const stageFailed = failed && i === 1
 
         return (
@@ -63,14 +64,27 @@ function Timeline({ app }: { app: Application }) {
 
 export function ApplicationsPage() {
   const [apps, setApps] = useState<Application[]>([])
+  const [loading, setLoading] = useState(true)
   const [expanded, setExpanded] = useState<number | null>(null)
 
   useEffect(() => {
-    const load = () => applicationsApi.list().then((r) => setApps(r.data.data)).catch(() => {})
-    load()
+    const load = () =>
+      applicationsApi.list()
+        .then((r) => setApps(r.data.data))
+        .catch(() => showToast({ title: 'Failed to load applications', variant: 'error' }))
+
+    load().finally(() => setLoading(false))
     const interval = setInterval(load, 30_000)
     return () => clearInterval(interval)
   }, [])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
 
   if (apps.length === 0)
     return <p className="text-muted-foreground text-center py-16">No applications yet. Browse jobs to apply!</p>

--- a/frontend/src/pages/candidate/ExamPage.tsx
+++ b/frontend/src/pages/candidate/ExamPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { AlertTriangle, ChevronLeft, ChevronRight } from 'lucide-react'
+import { AlertTriangle, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Progress } from '@/components/ui/progress'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import apiClient from '@/api/client'
+import { showToast } from '@/hooks/useToast'
 
 interface Question {
   id: number
@@ -22,11 +23,13 @@ interface ExamSession {
 
 export function ExamPage() {
   const [session, setSession] = useState<ExamSession | null>(null)
+  const [sessionLoading, setSessionLoading] = useState(true)
   const [answers, setAnswers] = useState<Record<number, string>>({})
   const [currentIdx, setCurrentIdx] = useState(0)
   const [secondsLeft, setSecondsLeft] = useState(0)
   const [submitted, setSubmitted] = useState(false)
   const [confirmLeave, setConfirmLeave] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
@@ -36,14 +39,20 @@ export function ExamPage() {
         setSecondsLeft(r.data.data.durationMinutes * 60)
       })
       .catch(() => {})
+      .finally(() => setSessionLoading(false))
   }, [])
 
   const submitExam = useCallback(async () => {
     if (!session) return
+    setSubmitting(true)
     try {
       await apiClient.post(`/exam/${session.examId}/submit`, { token: session.token })
       setSubmitted(true)
-    } catch { /* no-op */ }
+    } catch {
+      showToast({ title: 'Submission failed', description: 'Please try again. Your answers are saved.', variant: 'error' })
+    } finally {
+      setSubmitting(false)
+    }
   }, [session])
 
   useEffect(() => {
@@ -99,6 +108,14 @@ export function ExamPage() {
     )
   }
 
+  if (sessionLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
   if (!session) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
@@ -113,7 +130,6 @@ export function ExamPage() {
   const progressPct = (answeredCount / totalCount) * 100
 
   return (
-    // Sidebar is hidden via router — full-screen layout
     <div className="max-w-2xl mx-auto space-y-4">
       {/* Timer + progress */}
       <div className="flex items-center justify-between">
@@ -172,7 +188,7 @@ export function ExamPage() {
             Next <ChevronRight className="h-4 w-4 ml-1" />
           </Button>
         ) : (
-          <Button onClick={() => setConfirmLeave(true)} variant="default">
+          <Button onClick={() => setConfirmLeave(true)}>
             Submit Exam
           </Button>
         )}
@@ -210,7 +226,10 @@ export function ExamPage() {
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmLeave(false)}>Cancel</Button>
-            <Button onClick={submitExam}>Submit</Button>
+            <Button onClick={submitExam} disabled={submitting}>
+              {submitting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              Submit
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/frontend/src/pages/candidate/JobBoardPage.tsx
+++ b/frontend/src/pages/candidate/JobBoardPage.tsx
@@ -7,9 +7,11 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter }
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter as DFooter } from '@/components/ui/dialog'
 import { jobsApi, type JobPosting } from '@/api/jobs'
 import { applicationsApi } from '@/api/applications'
+import { showToast } from '@/hooks/useToast'
 
 export function JobBoardPage() {
   const [jobs, setJobs] = useState<JobPosting[]>([])
+  const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
   const [applied, setApplied] = useState<Set<number>>(new Set())
   const [applyJobId, setApplyJobId] = useState<number | null>(null)
@@ -20,7 +22,17 @@ export function JobBoardPage() {
   const fileRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    jobsApi.list({ status: 'OPEN' }).then((r) => setJobs(r.data.data)).catch(() => {})
+    Promise.all([
+      jobsApi.list({ status: 'OPEN' }),
+      applicationsApi.list(),
+    ])
+      .then(([jobsRes, appsRes]) => {
+        setJobs(jobsRes.data.data)
+        const appliedIds = new Set(appsRes.data.data.map((a) => a.jobId))
+        setApplied(appliedIds)
+      })
+      .catch(() => showToast({ title: 'Failed to load jobs', variant: 'error' }))
+      .finally(() => setLoading(false))
   }, [])
 
   const filtered = jobs.filter(
@@ -62,6 +74,7 @@ export function JobBoardPage() {
       setApplied((prev) => new Set([...prev, applyJobId]))
       setApplyJobId(null)
       setFile(null)
+      showToast({ title: 'Application submitted', variant: 'success' })
     } catch {
       setFileError('Submission failed — please try again')
     } finally {
@@ -84,40 +97,44 @@ export function JobBoardPage() {
         </div>
       </div>
 
-      {filtered.length === 0 && (
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : filtered.length === 0 ? (
         <p className="text-muted-foreground text-center py-16">No open positions found.</p>
-      )}
-
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-        {filtered.map((job) => (
-          <Card key={job.id} className="flex flex-col">
-            <CardHeader>
-              <div className="flex items-start justify-between gap-2">
-                <CardTitle className="text-base">{job.title}</CardTitle>
-                {applied.has(job.id) && <Badge variant="success">Applied</Badge>}
-              </div>
-              <CardDescription className="line-clamp-2">{job.description}</CardDescription>
-            </CardHeader>
-            <CardContent className="flex-1 space-y-1 text-sm text-muted-foreground">
-              <p>Degree: <span className="text-foreground">{job.requiredDegree}</span></p>
-              <p>Min height: <span className="text-foreground">{job.minHeightCm} cm</span></p>
-              <p>Closes: <span className="text-foreground">{job.closeDate}</span></p>
-              <p>Exam: <span className="text-foreground">{job.examDate}</span></p>
-            </CardContent>
-            <CardFooter>
-              {applied.has(job.id) ? (
-                <div className="flex items-center gap-2 text-green-400 text-sm">
-                  <CheckCircle className="h-4 w-4" /> Application submitted
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {filtered.map((job) => (
+            <Card key={job.id} className="flex flex-col">
+              <CardHeader>
+                <div className="flex items-start justify-between gap-2">
+                  <CardTitle className="text-base">{job.title}</CardTitle>
+                  {applied.has(job.id) && <Badge variant="success">Applied</Badge>}
                 </div>
-              ) : (
-                <Button className="w-full" onClick={() => { setApplyJobId(job.id); setFile(null); setFileError(null) }}>
-                  Apply Now
-                </Button>
-              )}
-            </CardFooter>
-          </Card>
-        ))}
-      </div>
+                <CardDescription className="line-clamp-2">{job.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1 space-y-1 text-sm text-muted-foreground">
+                <p>Degree: <span className="text-foreground">{job.requiredDegree}</span></p>
+                <p>Min height: <span className="text-foreground">{job.minHeightCm} cm</span></p>
+                <p>Closes: <span className="text-foreground">{job.closeDate}</span></p>
+                <p>Exam: <span className="text-foreground">{job.examDate}</span></p>
+              </CardContent>
+              <CardFooter>
+                {applied.has(job.id) ? (
+                  <div className="flex items-center gap-2 text-green-400 text-sm">
+                    <CheckCircle className="h-4 w-4" /> Application submitted
+                  </div>
+                ) : (
+                  <Button className="w-full" onClick={() => { setApplyJobId(job.id); setFile(null); setFileError(null) }}>
+                    Apply Now
+                  </Button>
+                )}
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      )}
 
       {/* Apply modal */}
       <Dialog open={applyJobId !== null} onOpenChange={() => setApplyJobId(null)}>


### PR DESCRIPTION
## Summary
- **FR-85** Job board with open positions grid, CV upload modal (PDF/DOCX ≤5 MB), drag-and-drop, applied-state persisted across refresh
- **FR-86** Application tracking page with animated status timeline, hard-filter failure handling, score details on expand, 30s auto-refresh
- **FR-87** Exam interface with countdown timer, per-answer autosave, question grid navigator, loading state, error toast on submit failure

## Test plan
- [ ] Browse jobs, apply with PDF/DOCX CV — applied badge appears, persists on refresh
- [ ] Invalid file type / oversized file shows validation error
- [ ] Applications page shows correct stage on timeline for all statuses including HARD_FILTER_FAILED
- [ ] Expand application card shows scores when available
- [ ] Exam page shows spinner while loading, "No active exam" when no session
- [ ] Timer counts down, red at <5 min, auto-submits at 0
- [ ] Selecting an answer autosaves; submission confirmation dialog works