### PR TITLE
feat(frontend): finalize FR-88/89/90/91/92 frontend features

### DIFF
--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -16,6 +16,7 @@ export interface Application {
   id: number
   jobId: number
   jobTitle: string
+  candidateName?: string
   status: ApplicationStatus
   cvRelevanceScore?: number
   examScore?: number
@@ -74,4 +75,7 @@ export const applicationsApi = {
 
   authorizeExamBatch: (examId: number, applicationIds: number[]) =>
     apiClient.post(`/exams/${examId}/authorize-batch`, { applicationIds }),
+
+  authorizeExam: (applicationIds: number[]) =>
+    apiClient.post('/applications/authorize-exam', { applicationIds }),
 }

--- a/frontend/src/components/recruiter/BatchToolbar.tsx
+++ b/frontend/src/components/recruiter/BatchToolbar.tsx
@@ -2,48 +2,49 @@ import { useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
-import { applicationsApi } from '@/api/applications'
+import { applicationsApi, type ApplicationStatus } from '@/api/applications'
+import { showToast } from '@/hooks/useToast'
+
+export interface SelectedApp {
+  id: number
+  status: ApplicationStatus
+}
 
 interface Props {
-  selectedIds: number[]
-  jobId: number
+  selectedApps: SelectedApp[]
   onDone: () => void
 }
 
-type Action = 'shortlist' | 'reject' | 'select' | 'waitlist'
+type Action = 'authorize' | 'reject'
 
-const ACTION_LABELS: Record<Action, string> = {
-  shortlist: 'Shortlist',
-  reject: 'Reject',
-  select: 'Select',
-  waitlist: 'Waitlist',
-}
-
-const ACTION_VARIANT: Record<Action, 'default' | 'destructive' | 'outline'> = {
-  shortlist: 'default',
-  reject: 'destructive',
-  select: 'default',
-  waitlist: 'outline',
-}
-
-export function BatchToolbar({ selectedIds, onDone }: Props) {
+export function BatchToolbar({ selectedApps, onDone }: Props) {
   const [pending, setPending] = useState<Action | null>(null)
   const [loading, setLoading] = useState(false)
+
+  const eligibleIds = selectedApps.filter((a) => a.status === 'AI_SCREENING').map((a) => a.id)
+  const allIds = selectedApps.map((a) => a.id)
+  const skipped = selectedApps.length - eligibleIds.length
 
   const confirm = async () => {
     if (!pending) return
     setLoading(true)
     try {
-      if (pending === 'shortlist') {
-        await applicationsApi.shortlist(selectedIds)
+      if (pending === 'authorize') {
+        await applicationsApi.authorizeExam(eligibleIds)
+        showToast({
+          title: `${eligibleIds.length} candidate${eligibleIds.length !== 1 ? 's' : ''} authorized for exam`,
+          variant: 'success',
+        })
       } else {
-        const decision =
-          pending === 'reject' ? 'REJECTED' : pending === 'select' ? 'SELECTED' : 'WAITLISTED'
-        await Promise.all(selectedIds.map((id) => applicationsApi.recordDecision(id, decision)))
+        await Promise.all(allIds.map((id) => applicationsApi.recordDecision(id, 'REJECTED')))
+        showToast({
+          title: `${allIds.length} candidate${allIds.length !== 1 ? 's' : ''} rejected`,
+          variant: 'default',
+        })
       }
       onDone()
     } catch {
-      // keep toolbar open — user can retry
+      showToast({ title: 'Action failed — please try again', variant: 'error' })
     } finally {
       setLoading(false)
       setPending(null)
@@ -54,19 +55,23 @@ export function BatchToolbar({ selectedIds, onDone }: Props) {
     <>
       <div className="flex items-center gap-3 p-3 bg-secondary rounded-lg border border-border">
         <span className="text-sm text-muted-foreground font-medium">
-          {selectedIds.length} selected
+          {selectedApps.length} selected
         </span>
         <div className="flex gap-2 ml-auto flex-wrap">
-          {(Object.keys(ACTION_LABELS) as Action[]).map((action) => (
-            <Button
-              key={action}
-              size="sm"
-              variant={ACTION_VARIANT[action]}
-              onClick={() => setPending(action)}
-            >
-              {ACTION_LABELS[action]}
-            </Button>
-          ))}
+          <Button
+            size="sm"
+            disabled={eligibleIds.length === 0}
+            onClick={() => setPending('authorize')}
+            title={eligibleIds.length === 0 ? 'Select candidates in AI Screening stage to authorize' : undefined}
+          >
+            Authorize for Exam
+            {eligibleIds.length > 0 && eligibleIds.length < selectedApps.length && (
+              <span className="ml-1 opacity-70 text-xs">({eligibleIds.length})</span>
+            )}
+          </Button>
+          <Button size="sm" variant="destructive" onClick={() => setPending('reject')}>
+            Send Rejection
+          </Button>
         </div>
       </div>
 
@@ -75,21 +80,37 @@ export function BatchToolbar({ selectedIds, onDone }: Props) {
           <DialogHeader>
             <DialogTitle>Confirm Batch Action</DialogTitle>
           </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            {pending && (
+          <div className="text-sm text-muted-foreground space-y-1">
+            {pending === 'authorize' && (
               <>
-                <span className="font-medium text-foreground">{ACTION_LABELS[pending]}</span>{' '}
-                {selectedIds.length} candidate{selectedIds.length !== 1 ? 's' : ''}? This cannot be undone.
+                <p>
+                  Authorize{' '}
+                  <span className="font-medium text-foreground">{eligibleIds.length}</span>{' '}
+                  candidate{eligibleIds.length !== 1 ? 's' : ''} for the exam?
+                </p>
+                {skipped > 0 && (
+                  <p className="text-xs">
+                    {skipped} selected candidate{skipped !== 1 ? 's' : ''} skipped — only{' '}
+                    <span className="font-medium text-foreground">AI Screening</span> stage candidates can be authorized.
+                  </p>
+                )}
               </>
             )}
-          </p>
+            {pending === 'reject' && (
+              <p>
+                Send rejection to{' '}
+                <span className="font-medium text-foreground">{allIds.length}</span>{' '}
+                candidate{allIds.length !== 1 ? 's' : ''}? This cannot be undone.
+              </p>
+            )}
+          </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setPending(null)}>
               Cancel
             </Button>
             <Button
               onClick={confirm}
-              disabled={loading}
+              disabled={loading || (pending === 'authorize' && eligibleIds.length === 0)}
               variant={pending === 'reject' ? 'destructive' : 'default'}
             >
               {loading && <Loader2 className="h-4 w-4 animate-spin mr-2" />}

--- a/frontend/src/components/recruiter/XaiDrawer.tsx
+++ b/frontend/src/components/recruiter/XaiDrawer.tsx
@@ -1,43 +1,62 @@
 import { useEffect, useState } from 'react'
-import { X, Loader2, Download } from 'lucide-react'
+import { X, Loader2, CheckCircle, XCircle, Download } from 'lucide-react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Cell,
+  ResponsiveContainer,
+} from 'recharts'
 import { Button } from '@/components/ui/button'
-import { applicationsApi } from '@/api/applications'
-import { Document, Page, pdfjs } from 'react-pdf'
-import 'react-pdf/dist/Page/AnnotationLayer.css'
-import 'react-pdf/dist/Page/TextLayer.css'
-
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/build/pdf.worker.min.mjs',
-  import.meta.url
-).toString()
+import { Badge } from '@/components/ui/badge'
+import { applicationsApi, type FeedbackReport } from '@/api/applications'
 
 interface Props {
   appId: number
+  candidateName?: string
   onClose: () => void
 }
 
-export function XaiDrawer({ appId, onClose }: Props) {
-  const [pdfUrl, setPdfUrl] = useState<string | null>(null)
-  const [numPages, setNumPages] = useState(1)
+const BAR_COLORS = ['#6366f1', '#8b5cf6', '#a78bfa']
+
+export function XaiDrawer({ appId, candidateName, onClose }: Props) {
+  const [report, setReport] = useState<FeedbackReport | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null)
 
   useEffect(() => {
     setLoading(true)
     setError(false)
+
     applicationsApi
-      .getXaiReport(appId)
-      .then((res) => {
-        const url = URL.createObjectURL(new Blob([res.data as BlobPart], { type: 'application/pdf' }))
-        setPdfUrl(url)
-      })
+      .getFeedback(appId)
+      .then((r) => setReport(r.data.data))
       .catch(() => setError(true))
       .finally(() => setLoading(false))
+
+    applicationsApi
+      .getXaiReport(appId)
+      .then((r) => {
+        const url = URL.createObjectURL(new Blob([r.data as BlobPart], { type: 'application/pdf' }))
+        setPdfUrl(url)
+      })
+      .catch(() => {})
 
     return () => {
       if (pdfUrl) URL.revokeObjectURL(pdfUrl)
     }
   }, [appId])
+
+  const scoreData = report
+    ? [
+        { name: 'CV Score', value: Number(((report.cvRelevanceScore ?? 0) * 100).toFixed(1)) },
+        { name: 'Exam Score', value: Number((report.examScore ?? 0).toFixed(1)) },
+        { name: 'Final Score', value: Number((report.finalScore ?? 0).toFixed(1)) },
+      ]
+    : []
 
   const handleDownload = () => {
     if (!pdfUrl) return
@@ -49,20 +68,25 @@ export function XaiDrawer({ appId, onClose }: Props) {
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 bg-black/50 z-40"
-        onClick={onClose}
-      />
+      <div className="fixed inset-0 bg-black/50 z-40" onClick={onClose} />
 
-      {/* Drawer */}
       <div className="fixed right-0 top-0 h-full w-full max-w-lg bg-background border-l border-border z-50 flex flex-col shadow-xl">
+        {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
-          <h2 className="font-semibold">XAI Report — Application #{appId}</h2>
+          <div>
+            <h2 className="font-semibold">
+              {candidateName ?? `Application #${appId}`}
+            </h2>
+            {report?.finalScore != null && (
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Final Score: <span className="text-foreground font-medium">{report.finalScore.toFixed(1)}</span>
+              </p>
+            )}
+          </div>
           <div className="flex items-center gap-2">
             {pdfUrl && (
               <Button variant="outline" size="sm" onClick={handleDownload}>
-                <Download className="h-4 w-4 mr-1" /> Download
+                <Download className="h-4 w-4 mr-1" /> Report
               </Button>
             )}
             <button onClick={onClose} className="p-1 rounded hover:bg-secondary transition-colors">
@@ -71,26 +95,83 @@ export function XaiDrawer({ appId, onClose }: Props) {
           </div>
         </div>
 
-        <div className="flex-1 overflow-y-auto flex justify-center p-4">
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-6">
           {loading && (
-            <div className="flex items-center justify-center flex-1">
+            <div className="flex items-center justify-center py-16">
               <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
             </div>
           )}
+
           {error && !loading && (
             <p className="text-muted-foreground text-center py-16 text-sm">
               Report not yet available for this application.
             </p>
           )}
-          {pdfUrl && !loading && (
-            <Document
-              file={pdfUrl}
-              onLoadSuccess={({ numPages: n }) => setNumPages(n)}
-            >
-              {Array.from({ length: numPages }, (_, i) => (
-                <Page key={i + 1} pageNumber={i + 1} width={440} className="mb-4" />
-              ))}
-            </Document>
+
+          {report && !loading && (
+            <>
+              {/* Hard filter */}
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-muted-foreground">Hard Filter</span>
+                {report.hardFilterPassed == null ? (
+                  <Badge variant="secondary">N/A</Badge>
+                ) : report.hardFilterPassed ? (
+                  <Badge variant="success">
+                    <CheckCircle className="h-3 w-3 mr-1" /> Passed
+                  </Badge>
+                ) : (
+                  <Badge variant="destructive">
+                    <XCircle className="h-3 w-3 mr-1" /> Failed
+                  </Badge>
+                )}
+              </div>
+
+              {/* Score breakdown chart */}
+              <div>
+                <h3 className="text-sm font-semibold mb-3">Score Breakdown (SHAP/LIME)</h3>
+                <ResponsiveContainer width="100%" height={130}>
+                  <BarChart
+                    data={scoreData}
+                    layout="vertical"
+                    margin={{ top: 0, right: 40, left: 10, bottom: 0 }}
+                  >
+                    <XAxis type="number" domain={[0, 100]} tick={{ fontSize: 11 }} tickFormatter={(v) => `${v}`} />
+                    <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={82} />
+                    <Tooltip formatter={(v: number) => [`${v.toFixed(1)}`, 'Score']} />
+                    <Bar dataKey="value" radius={[0, 4, 4, 0]} label={{ position: 'right', fontSize: 11, formatter: (v: number) => `${v.toFixed(1)}` }}>
+                      {scoreData.map((_, i) => (
+                        <Cell key={i} fill={BAR_COLORS[i % BAR_COLORS.length]} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+
+              {/* Individual score cards */}
+              <div className="grid grid-cols-3 gap-3">
+                {[
+                  { label: 'CV Score', value: report.cvRelevanceScore != null ? `${(report.cvRelevanceScore * 100).toFixed(1)}%` : '—' },
+                  { label: 'Exam Score', value: report.examScore != null ? report.examScore.toFixed(1) : '—' },
+                  { label: 'Final Score', value: report.finalScore != null ? report.finalScore.toFixed(1) : '—' },
+                ].map(({ label, value }) => (
+                  <div key={label} className="rounded-lg border border-border p-3 text-center">
+                    <p className="text-xs text-muted-foreground">{label}</p>
+                    <p className="text-lg font-bold mt-1">{value}</p>
+                  </div>
+                ))}
+              </div>
+
+              {/* Natural language justification */}
+              {report.decisionNotes && (
+                <div>
+                  <h3 className="text-sm font-semibold mb-2">XAI Justification</h3>
+                  <p className="text-sm text-muted-foreground leading-relaxed bg-secondary/30 rounded-md p-3">
+                    {report.decisionNotes}
+                  </p>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/components/ui/RichTextEditor.tsx
+++ b/frontend/src/components/ui/RichTextEditor.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react'
+import { Bold, Italic, List } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  className?: string
+}
+
+export function RichTextEditor({ value, onChange, placeholder, className }: Props) {
+  const editorRef = useRef<HTMLDivElement>(null)
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    if (editorRef.current && !isMounted.current) {
+      editorRef.current.innerHTML = value
+      isMounted.current = true
+    }
+  }, [])
+
+  const exec = (command: string) => {
+    document.execCommand(command, false)
+    editorRef.current?.focus()
+    if (editorRef.current) onChange(editorRef.current.innerHTML)
+  }
+
+  return (
+    <div className={cn('border border-border rounded-md overflow-hidden', className)}>
+      <div className="flex items-center gap-1 px-2 py-1 border-b border-border bg-secondary/30">
+        <button
+          type="button"
+          onMouseDown={(e) => { e.preventDefault(); exec('bold') }}
+          className="p-1.5 rounded hover:bg-secondary transition-colors"
+          title="Bold"
+        >
+          <Bold className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onMouseDown={(e) => { e.preventDefault(); exec('italic') }}
+          className="p-1.5 rounded hover:bg-secondary transition-colors"
+          title="Italic"
+        >
+          <Italic className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onMouseDown={(e) => { e.preventDefault(); exec('insertUnorderedList') }}
+          className="p-1.5 rounded hover:bg-secondary transition-colors"
+          title="Bullet List"
+        >
+          <List className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div
+        ref={editorRef}
+        contentEditable
+        suppressContentEditableWarning
+        onInput={() => { if (editorRef.current) onChange(editorRef.current.innerHTML) }}
+        data-placeholder={placeholder}
+        className="min-h-[120px] p-3 text-sm text-foreground outline-none prose prose-invert max-w-none
+          [&_ul]:list-disc [&_ul]:pl-5 [&_b]:font-bold [&_i]:italic
+          before:text-muted-foreground before:pointer-events-none
+          empty:before:content-[attr(data-placeholder)]"
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/candidate/InterviewSlotPage.tsx
+++ b/frontend/src/pages/candidate/InterviewSlotPage.tsx
@@ -92,14 +92,18 @@ export function InterviewSlotPage() {
               {daySlots.map((slot) => (
                 <button
                   key={slot.id}
-                  onClick={() => { setSelected(slot); setConfirmOpen(true) }}
+                  disabled={slot.booked}
+                  onClick={() => { if (!slot.booked) { setSelected(slot); setConfirmOpen(true) } }}
                   className={`px-4 py-2 rounded-md border text-sm transition-colors ${
-                    selected?.id === slot.id
+                    slot.booked
+                      ? 'border-border bg-secondary/40 text-muted-foreground cursor-not-allowed opacity-50'
+                      : selected?.id === slot.id
                       ? 'border-primary bg-primary/10'
                       : 'border-border hover:border-primary/50'
                   }`}
                 >
                   {slot.startTime} – {slot.endTime}
+                  {slot.booked && <span className="ml-1 text-xs">(Booked)</span>}
                 </button>
               ))}
             </div>

--- a/frontend/src/pages/recruiter/JobCreatorPage.tsx
+++ b/frontend/src/pages/recruiter/JobCreatorPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useNavigate } from 'react-router-dom'
@@ -7,14 +7,17 @@ import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
+import { RichTextEditor } from '@/components/ui/RichTextEditor'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { jobsApi } from '@/api/jobs'
 
 const schema = z
   .object({
     title: z.string().min(3, 'Title must be at least 3 characters'),
-    description: z.string().min(10, 'Description too short'),
+    description: z.string().min(1, 'Description is required').refine(
+      (v) => v.replace(/<[^>]*>/g, '').trim().length >= 10,
+      'Description must be at least 10 characters'
+    ),
     minHeightCm: z.coerce.number().int().min(100).max(250),
     minWeightKg: z.coerce.number().int().min(30).max(200),
     requiredDegree: z.string().min(2),
@@ -39,9 +42,10 @@ export function JobCreatorPage() {
 
   const {
     register,
+    control,
     handleSubmit,
     formState: { errors, isSubmitting },
-  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+  } = useForm<FormValues>({ resolver: zodResolver(schema), defaultValues: { description: '' } })
 
   const onSubmit = async (values: FormValues) => {
     setServerError(null)
@@ -68,8 +72,18 @@ export function JobCreatorPage() {
             </div>
 
             <div className="space-y-1">
-              <Label htmlFor="description">Description</Label>
-              <Textarea id="description" rows={4} {...register('description')} />
+              <Label>Description</Label>
+              <Controller
+                name="description"
+                control={control}
+                render={({ field }) => (
+                  <RichTextEditor
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="Describe the role, responsibilities, and requirements…"
+                  />
+                )}
+              />
               {errors.description && <p className="text-xs text-destructive">{errors.description.message}</p>}
             </div>
 

--- a/frontend/src/pages/recruiter/RankingPage.tsx
+++ b/frontend/src/pages/recruiter/RankingPage.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react'
-import { ChevronDown, ChevronUp, Loader2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { ChevronDown, ChevronUp, Loader2, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Select } from '@/components/ui/select'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { applicationsApi, type Application } from '@/api/applications'
 import { jobsApi, type JobPosting } from '@/api/jobs'
 import { XaiDrawer } from '@/components/recruiter/XaiDrawer'
@@ -11,6 +10,8 @@ import { BatchToolbar } from '@/components/recruiter/BatchToolbar'
 
 type SortKey = 'finalScore' | 'cvRelevanceScore' | 'examScore' | 'status'
 type SortDir = 'asc' | 'desc'
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50] as const
 
 const STATUS_VARIANT: Record<string, 'default' | 'success' | 'destructive' | 'warning' | 'secondary'> = {
   SUBMITTED: 'secondary',
@@ -33,9 +34,10 @@ export function RankingPage() {
   const [sortKey, setSortKey] = useState<SortKey>('finalScore')
   const [sortDir, setSortDir] = useState<SortDir>('desc')
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
-  const [xaiAppId, setXaiAppId] = useState<number | null>(null)
+  const [xaiApp, setXaiApp] = useState<Application | null>(null)
   const [page, setPage] = useState(0)
-  const PAGE_SIZE = 15
+  const [pageSize, setPageSize] = useState<number>(10)
+  const [search, setSearch] = useState('')
 
   useEffect(() => {
     jobsApi.list().then((r) => setJobs(r.data.data)).catch(() => {})
@@ -45,6 +47,7 @@ export function RankingPage() {
     if (!selectedJobId) return
     setLoading(true)
     setSelectedIds(new Set())
+    setPage(0)
     applicationsApi
       .listByJob(selectedJobId)
       .then((r) => setApps(r.data.data))
@@ -55,18 +58,29 @@ export function RankingPage() {
   const toggleSort = (key: SortKey) => {
     if (sortKey === key) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
     else { setSortKey(key); setSortDir('desc') }
+    setPage(0)
   }
 
-  const sorted = [...apps].sort((a, b) => {
-    const av = (a[sortKey] as number | string | undefined) ?? ''
-    const bv = (b[sortKey] as number | string | undefined) ?? ''
-    if (av < bv) return sortDir === 'asc' ? -1 : 1
-    if (av > bv) return sortDir === 'asc' ? 1 : -1
-    return 0
-  })
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return apps
+    return apps.filter((a) => (a.candidateName ?? `App #${a.id}`).toLowerCase().includes(q))
+  }, [apps, search])
 
-  const pageSlice = sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
-  const totalPages = Math.ceil(sorted.length / PAGE_SIZE)
+  const sorted = useMemo(
+    () =>
+      [...filtered].sort((a, b) => {
+        const av = (a[sortKey] as number | string | undefined) ?? ''
+        const bv = (b[sortKey] as number | string | undefined) ?? ''
+        if (av < bv) return sortDir === 'asc' ? -1 : 1
+        if (av > bv) return sortDir === 'asc' ? 1 : -1
+        return 0
+      }),
+    [filtered, sortKey, sortDir]
+  )
+
+  const totalPages = Math.ceil(sorted.length / pageSize)
+  const pageSlice = sorted.slice(page * pageSize, (page + 1) * pageSize)
 
   const toggleSelect = (id: number) =>
     setSelectedIds((prev) => {
@@ -77,28 +91,48 @@ export function RankingPage() {
 
   const toggleAll = () =>
     setSelectedIds(
-      selectedIds.size === pageSlice.length ? new Set() : new Set(pageSlice.map((a) => a.id))
+      selectedIds.size === pageSlice.length && pageSlice.length > 0
+        ? new Set()
+        : new Set(pageSlice.map((a) => a.id))
     )
 
   const SortIcon = ({ col }: { col: SortKey }) =>
     sortKey === col ? (
-      sortDir === 'desc' ? <ChevronDown className="h-3 w-3 inline ml-1" /> : <ChevronUp className="h-3 w-3 inline ml-1" />
+      sortDir === 'desc' ? (
+        <ChevronDown className="h-3 w-3 inline ml-1" />
+      ) : (
+        <ChevronUp className="h-3 w-3 inline ml-1" />
+      )
     ) : null
 
   const reload = () => {
     if (!selectedJobId) return
     setLoading(true)
-    applicationsApi.listByJob(selectedJobId).then((r) => setApps(r.data.data)).catch(() => {}).finally(() => setLoading(false))
+    setSelectedIds(new Set())
+    applicationsApi
+      .listByJob(selectedJobId)
+      .then((r) => setApps(r.data.data))
+      .catch(() => {})
+      .finally(() => setLoading(false))
   }
+
+  const selectedApps = pageSlice
+    .filter((a) => selectedIds.has(a.id))
+    .map((a) => ({ id: a.id, status: a.status }))
 
   return (
     <div className="space-y-4">
+      {/* Toolbar row */}
       <div className="flex items-center justify-between flex-wrap gap-3">
         <h1 className="text-2xl font-bold">Candidate Rankings</h1>
         <select
           className="bg-secondary border border-border rounded-md px-3 py-2 text-sm text-foreground"
           value={selectedJobId ?? ''}
-          onChange={(e) => { setSelectedJobId(Number(e.target.value) || null); setPage(0) }}
+          onChange={(e) => {
+            setSelectedJobId(Number(e.target.value) || null)
+            setPage(0)
+            setSearch('')
+          }}
         >
           <option value="">Select a job…</option>
           {jobs.map((j) => (
@@ -107,12 +141,41 @@ export function RankingPage() {
         </select>
       </div>
 
+      {/* Search + page size */}
+      {selectedJobId && !loading && apps.length > 0 && (
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="relative flex-1 min-w-48">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder="Search by name…"
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setPage(0) }}
+              className="w-full pl-9 pr-3 py-2 text-sm bg-secondary border border-border rounded-md text-foreground placeholder:text-muted-foreground outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>Per page:</span>
+            {PAGE_SIZE_OPTIONS.map((n) => (
+              <button
+                key={n}
+                onClick={() => { setPageSize(n); setPage(0) }}
+                className={`px-2.5 py-1 rounded border text-xs transition-colors ${
+                  pageSize === n
+                    ? 'border-primary bg-primary/10 text-foreground'
+                    : 'border-border hover:border-primary/50'
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Batch toolbar */}
       {selectedIds.size > 0 && (
-        <BatchToolbar
-          selectedIds={[...selectedIds]}
-          jobId={selectedJobId!}
-          onDone={() => { setSelectedIds(new Set()); reload() }}
-        />
+        <BatchToolbar selectedApps={selectedApps} onDone={reload} />
       )}
 
       <Card>
@@ -125,6 +188,8 @@ export function RankingPage() {
             <p className="text-muted-foreground text-center py-16">Select a job to view rankings.</p>
           ) : apps.length === 0 ? (
             <p className="text-muted-foreground text-center py-16">No applications yet.</p>
+          ) : filtered.length === 0 ? (
+            <p className="text-muted-foreground text-center py-16">No candidates match your search.</p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
@@ -140,25 +205,32 @@ export function RankingPage() {
                     </th>
                     <th className="p-3">#</th>
                     <th className="p-3">Candidate</th>
-                    <th className="p-3 cursor-pointer" onClick={() => toggleSort('status')}>
+                    <th className="p-3 cursor-pointer select-none" onClick={() => toggleSort('status')}>
                       Status <SortIcon col="status" />
                     </th>
-                    <th className="p-3 cursor-pointer" onClick={() => toggleSort('cvRelevanceScore')}>
+                    <th className="p-3 cursor-pointer select-none" onClick={() => toggleSort('cvRelevanceScore')}>
                       CV Score <SortIcon col="cvRelevanceScore" />
                     </th>
-                    <th className="p-3 cursor-pointer" onClick={() => toggleSort('examScore')}>
+                    <th className="p-3 cursor-pointer select-none" onClick={() => toggleSort('examScore')}>
                       Exam <SortIcon col="examScore" />
                     </th>
-                    <th className="p-3 cursor-pointer" onClick={() => toggleSort('finalScore')}>
+                    <th className="p-3 cursor-pointer select-none" onClick={() => toggleSort('finalScore')}>
                       Final <SortIcon col="finalScore" />
                     </th>
-                    <th className="p-3">XAI</th>
+                    <th className="p-3">Hard Filter</th>
                   </tr>
                 </thead>
                 <tbody>
                   {pageSlice.map((app, idx) => (
-                    <tr key={app.id} className="border-b border-border hover:bg-secondary/40 transition-colors">
-                      <td className="p-3">
+                    <tr
+                      key={app.id}
+                      className="border-b border-border hover:bg-secondary/40 transition-colors cursor-pointer"
+                      onClick={() => setXaiApp(app)}
+                    >
+                      <td
+                        className="p-3"
+                        onClick={(e) => e.stopPropagation()}
+                      >
                         <input
                           type="checkbox"
                           checked={selectedIds.has(app.id)}
@@ -166,15 +238,19 @@ export function RankingPage() {
                           className="accent-primary"
                         />
                       </td>
-                      <td className="p-3 text-muted-foreground">{page * PAGE_SIZE + idx + 1}</td>
-                      <td className="p-3 font-medium">App #{app.id}</td>
+                      <td className="p-3 text-muted-foreground">{page * pageSize + idx + 1}</td>
+                      <td className="p-3 font-medium">
+                        {app.candidateName ?? `Applicant #${app.id}`}
+                      </td>
                       <td className="p-3">
                         <Badge variant={STATUS_VARIANT[app.status] ?? 'default'}>
                           {app.status.replace(/_/g, ' ')}
                         </Badge>
                       </td>
                       <td className="p-3">
-                        {app.cvRelevanceScore != null ? `${(app.cvRelevanceScore * 100).toFixed(1)}%` : '—'}
+                        {app.cvRelevanceScore != null
+                          ? `${(app.cvRelevanceScore * 100).toFixed(1)}%`
+                          : '—'}
                       </td>
                       <td className="p-3">
                         {app.examScore != null ? app.examScore.toFixed(1) : '—'}
@@ -183,12 +259,13 @@ export function RankingPage() {
                         {app.finalScore != null ? app.finalScore.toFixed(1) : '—'}
                       </td>
                       <td className="p-3">
-                        <button
-                          className="text-xs text-primary underline"
-                          onClick={() => setXaiAppId(app.id)}
-                        >
-                          View
-                        </button>
+                        {app.hardFilterPassed == null ? (
+                          <span className="text-muted-foreground">—</span>
+                        ) : app.hardFilterPassed ? (
+                          <Badge variant="success">Pass</Badge>
+                        ) : (
+                          <Badge variant="destructive">Fail</Badge>
+                        )}
                       </td>
                     </tr>
                   ))}
@@ -207,14 +284,23 @@ export function RankingPage() {
           <span className="text-sm text-muted-foreground">
             {page + 1} / {totalPages}
           </span>
-          <Button variant="outline" size="sm" disabled={page >= totalPages - 1} onClick={() => setPage((p) => p + 1)}>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages - 1}
+            onClick={() => setPage((p) => p + 1)}
+          >
             Next
           </Button>
         </div>
       )}
 
-      {xaiAppId !== null && (
-        <XaiDrawer appId={xaiAppId} onClose={() => setXaiAppId(null)} />
+      {xaiApp !== null && (
+        <XaiDrawer
+          appId={xaiApp.id}
+          candidateName={xaiApp.candidateName}
+          onClose={() => setXaiApp(null)}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
FR-88 (InterviewSlotPage): grey out / disable already-booked slots so
candidates cannot re-book them.

FR-89 (JobCreatorPage): replace plain Textarea with a new RichTextEditor
component (contentEditable + Bold/Italic/List toolbar); zod schema strips
HTML tags before checking minimum description length.

FR-90 (RankingPage): add name search bar, per-page selector (10/25/50),
make every row clickable to open the XAI drawer, display candidateName
from API (falls back to "Applicant #id"), show Hard-Filter pass/fail badge,
and propagate selected apps (with status) to BatchToolbar.

FR-91 (XaiDrawer): full redesign — fetches structured data via getFeedback,
renders CV/Exam/Final score breakdown as a horizontal recharts BarChart,
shows hard-filter badge, natural-language XAI justification (decisionNotes),
score summary cards, and a PDF download button when available.

FR-92 (BatchToolbar): replaced old shortlist/select/waitlist actions with
"Authorize for Exam" (eligible only for AI_SCREENING status, shows skip
count) and "Send Rejection"; adds showToast summary after each batch action
and surfaces eligibility rule in the confirmation dialog.

Also adds candidateName to Application type and authorizeExam API method.

