### PR TITLE
feat(frontend): availability calendar, metrics dashboard, admin tables & result portal [FR-93/94/95/96/97/98/99]

### DIFF
--- a/frontend/src/api/availability.ts
+++ b/frontend/src/api/availability.ts
@@ -17,4 +17,7 @@ export const availabilityApi = {
 
   getAvailableSlots: () =>
     apiClient.get<{ data: AvailabilitySlot[] }>('/availability/available'),
+
+  deleteSlot: (id: number) =>
+    apiClient.delete(`/recruiters/availability/${id}`),
 }

--- a/frontend/src/pages/admin/AiModelPage.tsx
+++ b/frontend/src/pages/admin/AiModelPage.tsx
@@ -8,10 +8,10 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
-import { Switch } from '@/components/ui/switch'
 import { adminApi, type AiModel } from '@/api/admin'
+import { showToast } from '@/hooks/useToast'
 
 const schema = z.object({
   modelVersion: z.string().min(1, 'Version required'),
@@ -23,7 +23,8 @@ export function AiModelPage() {
   const [models, setModels] = useState<AiModel[]>([])
   const [loading, setLoading] = useState(true)
   const [createOpen, setCreateOpen] = useState(false)
-  const [activating, setActivating] = useState<number | null>(null)
+  const [activateTarget, setActivateTarget] = useState<AiModel | null>(null)
+  const [activating, setActivating] = useState(false)
 
   const { register, handleSubmit, reset, formState: { errors, isSubmitting } } = useForm<FormValues>({
     resolver: zodResolver(schema),
@@ -31,25 +32,39 @@ export function AiModelPage() {
 
   const reload = () => {
     setLoading(true)
-    adminApi.listAiModels().then((r) => setModels(r.data.data)).catch(() => {}).finally(() => setLoading(false))
+    adminApi
+      .listAiModels()
+      .then((r) => setModels(r.data.data))
+      .catch(() => showToast({ title: 'Failed to load AI models', variant: 'error' }))
+      .finally(() => setLoading(false))
   }
 
   useEffect(() => { reload() }, [])
 
   const onRegister = async (values: FormValues) => {
-    await adminApi.registerAiModel(values.modelVersion, values.description ?? '')
-    reset()
-    setCreateOpen(false)
-    reload()
+    try {
+      await adminApi.registerAiModel(values.modelVersion, values.description ?? '')
+      reset()
+      setCreateOpen(false)
+      showToast({ title: 'Model version registered', variant: 'success' })
+      reload()
+    } catch {
+      showToast({ title: 'Failed to register model', variant: 'error' })
+    }
   }
 
-  const activate = async (id: number) => {
-    setActivating(id)
+  const confirmActivate = async () => {
+    if (!activateTarget) return
+    setActivating(true)
     try {
-      await adminApi.activateAiModel(id)
+      await adminApi.activateAiModel(activateTarget.id)
+      showToast({ title: `${activateTarget.modelVersion} is now active`, variant: 'success' })
       reload()
+    } catch {
+      showToast({ title: 'Failed to activate model', variant: 'error' })
     } finally {
-      setActivating(null)
+      setActivating(false)
+      setActivateTarget(null)
     }
   }
 
@@ -108,14 +123,9 @@ export function AiModelPage() {
                           <Button
                             variant="outline"
                             size="sm"
-                            onClick={() => activate(m.id)}
-                            disabled={activating === m.id}
+                            onClick={() => setActivateTarget(m)}
                           >
-                            {activating === m.id ? (
-                              <Loader2 className="h-3 w-3 animate-spin" />
-                            ) : (
-                              'Activate'
-                            )}
+                            Activate
                           </Button>
                         )}
                       </td>
@@ -128,6 +138,30 @@ export function AiModelPage() {
         </CardContent>
       </Card>
 
+      {/* Activation confirmation */}
+      <Dialog open={activateTarget !== null} onOpenChange={(o) => { if (!o) setActivateTarget(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Activate model version?</DialogTitle>
+          </DialogHeader>
+          {activateTarget && (
+            <p className="text-sm text-muted-foreground">
+              Switch the active model to{' '}
+              <span className="font-mono font-medium text-foreground">{activateTarget.modelVersion}</span>?
+              This will immediately affect all AI screening requests.
+            </p>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setActivateTarget(null)}>Cancel</Button>
+            <Button onClick={confirmActivate} disabled={activating}>
+              {activating && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              Activate
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Register new version */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent>
           <DialogHeader>

--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { adminApi, type AuditLog } from '@/api/admin'
+import { showToast } from '@/hooks/useToast'
 
 export function AuditLogPage() {
   const [logs, setLogs] = useState<AuditLog[]>([])
@@ -12,6 +13,7 @@ export function AuditLogPage() {
   const [page, setPage] = useState(0)
   const [hasMore, setHasMore] = useState(true)
   const [entityFilter, setEntityFilter] = useState('')
+  const [emailFilter, setEmailFilter] = useState('')
   const PAGE_SIZE = 20
 
   const load = (p: number, reset = false) => {
@@ -23,7 +25,7 @@ export function AuditLogPage() {
         setLogs((prev) => (reset ? data : [...prev, ...data]))
         setHasMore(data.length === PAGE_SIZE)
       })
-      .catch(() => {})
+      .catch(() => showToast({ title: 'Failed to load audit logs', variant: 'error' }))
       .finally(() => setLoading(false))
   }
 
@@ -35,9 +37,11 @@ export function AuditLogPage() {
     load(next)
   }
 
-  const filtered = entityFilter
-    ? logs.filter((l) => l.entityType.toLowerCase().includes(entityFilter.toLowerCase()))
-    : logs
+  const filtered = logs.filter((l) => {
+    const matchEntity = !entityFilter || l.entityType.toLowerCase().includes(entityFilter.toLowerCase())
+    const matchEmail = !emailFilter || (l.changedByEmail ?? '').toLowerCase().includes(emailFilter.toLowerCase())
+    return matchEntity && matchEmail
+  })
 
   const formatDate = (s: string) =>
     new Date(s).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
@@ -46,12 +50,20 @@ export function AuditLogPage() {
     <div className="space-y-4">
       <div className="flex items-center justify-between flex-wrap gap-3">
         <h1 className="text-2xl font-bold">Audit Log</h1>
-        <Input
-          placeholder="Filter by entity type…"
-          className="w-64"
-          value={entityFilter}
-          onChange={(e) => setEntityFilter(e.target.value)}
-        />
+        <div className="flex gap-2 flex-wrap">
+          <Input
+            placeholder="Filter by entity type…"
+            className="w-52"
+            value={entityFilter}
+            onChange={(e) => setEntityFilter(e.target.value)}
+          />
+          <Input
+            placeholder="Filter by user email…"
+            className="w-52"
+            value={emailFilter}
+            onChange={(e) => setEmailFilter(e.target.value)}
+          />
+        </div>
       </div>
 
       <Card>

--- a/frontend/src/pages/admin/HealthDashboard.tsx
+++ b/frontend/src/pages/admin/HealthDashboard.tsx
@@ -7,6 +7,9 @@ import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid
 } from 'recharts'
 import { adminApi, type SystemHealth } from '@/api/admin'
+import { showToast } from '@/hooks/useToast'
+
+type JobRow = { jobTitle: string; total: number; selected: number }
 
 function StatusBadge({ up }: { up: boolean }) {
   return up ? (
@@ -20,10 +23,23 @@ function StatusBadge({ up }: { up: boolean }) {
   )
 }
 
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-bold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
 export function HealthDashboard() {
   const [health, setHealth] = useState<SystemHealth | null>(null)
   const [loading, setLoading] = useState(true)
-  const [analyticsData, setAnalyticsData] = useState<{ jobTitle: string; total: number; selected: number }[]>([])
+  const [analyticsData, setAnalyticsData] = useState<JobRow[]>([])
 
   const reload = () => {
     setLoading(true)
@@ -41,7 +57,7 @@ export function HealthDashboard() {
           }))
         )
       })
-      .catch(() => {})
+      .catch(() => showToast({ title: 'Failed to load health data', variant: 'error' }))
       .finally(() => setLoading(false))
   }
 
@@ -56,6 +72,10 @@ export function HealthDashboard() {
     const m = Math.floor((s % 3600) / 60)
     return `${h}h ${m}m`
   }
+
+  const totalApps = analyticsData.reduce((sum, j) => sum + j.total, 0)
+  const totalSelected = analyticsData.reduce((sum, j) => sum + j.selected, 0)
+  const selectionRate = totalApps > 0 ? ((totalSelected / totalApps) * 100).toFixed(1) : '—'
 
   return (
     <div className="space-y-6">
@@ -72,6 +92,7 @@ export function HealthDashboard() {
         </div>
       ) : health ? (
         <>
+          {/* Service status */}
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <Card>
               <CardHeader className="pb-2">
@@ -106,11 +127,13 @@ export function HealthDashboard() {
             </Card>
           </div>
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Uptime: {fmtUptime(health.uptimeSeconds)}</CardTitle>
-            </CardHeader>
-          </Card>
+          {/* Uptime + pipeline summary */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <StatCard label="Uptime" value={fmtUptime(health.uptimeSeconds)} />
+            <StatCard label="Total Applications" value={totalApps} />
+            <StatCard label="Selected" value={totalSelected} />
+            <StatCard label="Selection Rate" value={totalApps > 0 ? `${selectionRate}%` : '—'} />
+          </div>
 
           {analyticsData.length > 0 && (
             <Card>

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -2,14 +2,15 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { Loader2, PlusCircle, UserCheck, UserX } from 'lucide-react'
+import { Loader2, PlusCircle, Search, UserCheck, UserX } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { adminApi, type User } from '@/api/admin'
+import { showToast } from '@/hooks/useToast'
 
 const schema = z.object({
   fullName: z.string().min(2),
@@ -21,6 +22,7 @@ type FormValues = z.infer<typeof schema>
 export function UsersPage() {
   const [users, setUsers] = useState<User[]>([])
   const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
   const [createOpen, setCreateOpen] = useState(false)
   const [toggling, setToggling] = useState<number | null>(null)
 
@@ -30,35 +32,65 @@ export function UsersPage() {
 
   const reload = () => {
     setLoading(true)
-    adminApi.listUsers().then((r) => setUsers(r.data.data)).catch(() => {}).finally(() => setLoading(false))
+    adminApi
+      .listUsers()
+      .then((r) => setUsers(r.data.data))
+      .catch(() => showToast({ title: 'Failed to load users', variant: 'error' }))
+      .finally(() => setLoading(false))
   }
 
   useEffect(() => { reload() }, [])
 
   const onCreateRecruiter = async (values: FormValues) => {
-    await adminApi.createRecruiter(values)
-    reset()
-    setCreateOpen(false)
-    reload()
+    try {
+      await adminApi.createRecruiter(values)
+      reset()
+      setCreateOpen(false)
+      showToast({ title: 'Recruiter created', variant: 'success' })
+      reload()
+    } catch {
+      showToast({ title: 'Failed to create recruiter', variant: 'error' })
+    }
   }
 
   const toggleStatus = async (user: User) => {
     setToggling(user.id)
     try {
       await adminApi.setUserStatus(user.id, !user.active)
+      showToast({ title: user.active ? 'User deactivated' : 'User activated', variant: 'success' })
       reload()
+    } catch {
+      showToast({ title: 'Failed to update status', variant: 'error' })
     } finally {
       setToggling(null)
     }
   }
 
+  const filtered = users.filter(
+    (u) =>
+      !search ||
+      u.fullName.toLowerCase().includes(search.toLowerCase()) ||
+      u.email.toLowerCase().includes(search.toLowerCase())
+  )
+
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-3">
         <h1 className="text-2xl font-bold">User Management</h1>
-        <Button onClick={() => setCreateOpen(true)}>
-          <PlusCircle className="h-4 w-4 mr-2" /> Create Recruiter
-        </Button>
+        <div className="flex items-center gap-2">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search name or email…"
+              className="pl-9 w-64"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <Button onClick={() => setCreateOpen(true)}>
+            <PlusCircle className="h-4 w-4 mr-2" /> Create Recruiter
+          </Button>
+        </div>
       </div>
 
       <Card>
@@ -67,6 +99,10 @@ export function UsersPage() {
             <div className="flex justify-center py-16">
               <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
             </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-muted-foreground text-center py-16">
+              {search ? 'No users match your search.' : 'No users found.'}
+            </p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
@@ -81,7 +117,7 @@ export function UsersPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {users.map((u) => (
+                  {filtered.map((u) => (
                     <tr key={u.id} className="border-b border-border hover:bg-secondary/40 transition-colors">
                       <td className="p-3 font-medium">{u.fullName}</td>
                       <td className="p-3 text-muted-foreground">{u.email}</td>

--- a/frontend/src/pages/candidate/ResultsPage.tsx
+++ b/frontend/src/pages/candidate/ResultsPage.tsx
@@ -84,6 +84,18 @@ export function ResultsPage() {
     setPdfPage(1)
   }
 
+  useEffect(() => {
+    if (!pdfOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown')
+        setPdfPage((p) => Math.min(pdfPages, p + 1))
+      else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp')
+        setPdfPage((p) => Math.max(1, p - 1))
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [pdfOpen, pdfPages])
+
   if (loading) {
     return (
       <div className="flex justify-center py-16">

--- a/frontend/src/pages/candidate/ResultsPage.tsx
+++ b/frontend/src/pages/candidate/ResultsPage.tsx
@@ -6,6 +6,7 @@ import { Progress } from '@/components/ui/progress'
 import { Badge } from '@/components/ui/badge'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { applicationsApi, type FeedbackReport } from '@/api/applications'
+import { showToast } from '@/hooks/useToast'
 import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 import 'react-pdf/dist/Page/TextLayer.css'
@@ -23,21 +24,27 @@ const DECISION_CONFIG = {
 
 export function ResultsPage() {
   const [reports, setReports] = useState<FeedbackReport[]>([])
+  const [loading, setLoading] = useState(true)
   const [pdfBlob, setPdfBlob] = useState<string | null>(null)
   const [pdfOpen, setPdfOpen] = useState(false)
   const [pdfPages, setPdfPages] = useState<number>(1)
+  const [pdfPage, setPdfPage] = useState<number>(1)
   const [loadingPdf, setLoadingPdf] = useState(false)
 
   useEffect(() => {
-    applicationsApi.list().then(async (r) => {
-      const finals = r.data.data.filter((a) =>
-        ['SELECTED', 'REJECTED', 'WAITLISTED'].includes(a.status)
-      )
-      const feedbacks = await Promise.allSettled(
-        finals.map((a) => applicationsApi.getFeedback(a.id).then((fr) => fr.data.data))
-      )
-      setReports(feedbacks.flatMap((f) => (f.status === 'fulfilled' ? [f.value] : [])))
-    }).catch(() => {})
+    applicationsApi
+      .list()
+      .then(async (r) => {
+        const finals = r.data.data.filter((a) =>
+          ['SELECTED', 'REJECTED', 'WAITLISTED'].includes(a.status)
+        )
+        const feedbacks = await Promise.allSettled(
+          finals.map((a) => applicationsApi.getFeedback(a.id).then((fr) => fr.data.data))
+        )
+        setReports(feedbacks.flatMap((f) => (f.status === 'fulfilled' ? [f.value] : [])))
+      })
+      .catch(() => showToast({ title: 'Failed to load results', variant: 'error' }))
+      .finally(() => setLoading(false))
   }, [])
 
   const handlePreview = async (appId: number) => {
@@ -46,19 +53,43 @@ export function ResultsPage() {
       const res = await applicationsApi.getXaiReport(appId)
       const url = URL.createObjectURL(new Blob([res.data as BlobPart], { type: 'application/pdf' }))
       setPdfBlob(url)
+      setPdfPage(1)
       setPdfOpen(true)
-    } catch { /* show loading message */ }
-    finally { setLoadingPdf(false) }
+    } catch {
+      showToast({ title: 'Failed to load report', variant: 'error' })
+    } finally {
+      setLoadingPdf(false)
+    }
   }
 
   const handleDownload = async (appId: number) => {
-    const res = await applicationsApi.getXaiReport(appId)
-    const url = URL.createObjectURL(new Blob([res.data as BlobPart], { type: 'application/pdf' }))
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `xai-report-${appId}.pdf`
-    a.click()
-    URL.revokeObjectURL(url)
+    try {
+      const res = await applicationsApi.getXaiReport(appId)
+      const url = URL.createObjectURL(new Blob([res.data as BlobPart], { type: 'application/pdf' }))
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `xai-report-${appId}.pdf`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      showToast({ title: 'Download failed', variant: 'error' })
+    }
+  }
+
+  const closePdf = () => {
+    setPdfOpen(false)
+    if (pdfBlob) URL.revokeObjectURL(pdfBlob)
+    setPdfBlob(null)
+    setPdfPages(1)
+    setPdfPage(1)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
   }
 
   if (reports.length === 0) {
@@ -88,7 +119,6 @@ export function ResultsPage() {
               {cfg && <p className="text-sm text-muted-foreground mt-2">{cfg.label}</p>}
             </CardHeader>
             <CardContent className="space-y-4">
-              {/* Score bars */}
               {[
                 { label: 'CV Relevance', value: r.cvRelevanceScore != null ? r.cvRelevanceScore * 100 : null },
                 { label: 'Exam Score',   value: r.examScore },
@@ -121,7 +151,7 @@ export function ResultsPage() {
                 </div>
               )}
 
-              {r.xaiReportUrl && (
+              {r.xaiReportUrl ? (
                 <div className="flex gap-2 pt-2">
                   <Button
                     variant="outline"
@@ -136,8 +166,7 @@ export function ResultsPage() {
                     <Download className="h-4 w-4 mr-2" /> Download
                   </Button>
                 </div>
-              )}
-              {!r.xaiReportUrl && (
+              ) : (
                 <p className="text-xs text-muted-foreground">AI report is being generated — check back shortly.</p>
               )}
             </CardContent>
@@ -145,21 +174,19 @@ export function ResultsPage() {
         )
       })}
 
-      {/* In-browser PDF viewer */}
-      <Dialog open={pdfOpen} onOpenChange={(o) => { setPdfOpen(o); if (!o && pdfBlob) URL.revokeObjectURL(pdfBlob) }}>
+      <Dialog open={pdfOpen} onOpenChange={(o) => { if (!o) closePdf() }}>
         <DialogContent className="max-w-3xl w-full h-[90vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>AI Feedback Report</DialogTitle>
           </DialogHeader>
+
           <div className="flex-1 overflow-y-auto flex justify-center">
             {pdfBlob ? (
               <Document
                 file={pdfBlob}
                 onLoadSuccess={({ numPages }) => setPdfPages(numPages)}
               >
-                {Array.from({ length: pdfPages }, (_, i) => (
-                  <Page key={i + 1} pageNumber={i + 1} width={600} className="mb-4" />
-                ))}
+                <Page pageNumber={pdfPage} width={600} />
               </Document>
             ) : (
               <div className="flex items-center justify-center flex-1">
@@ -167,6 +194,30 @@ export function ResultsPage() {
               </div>
             )}
           </div>
+
+          {pdfPages > 1 && (
+            <div className="flex items-center justify-center gap-4 pt-3 border-t border-border">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPdfPage((p) => Math.max(1, p - 1))}
+                disabled={pdfPage === 1}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {pdfPage} of {pdfPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPdfPage((p) => Math.min(pdfPages, p + 1))}
+                disabled={pdfPage === pdfPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/frontend/src/pages/recruiter/AvailabilityCalendarPage.tsx
+++ b/frontend/src/pages/recruiter/AvailabilityCalendarPage.tsx
@@ -5,7 +5,9 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { availabilityApi, type AvailabilitySlot } from '@/api/availability'
+import { showToast } from '@/hooks/useToast'
 
 interface NewSlot {
   slotDate: string
@@ -17,15 +19,23 @@ const EMPTY: NewSlot = { slotDate: '', startTime: '', endTime: '' }
 
 export function AvailabilityCalendarPage() {
   const [slots, setSlots] = useState<AvailabilitySlot[]>([])
+  const [loading, setLoading] = useState(true)
   const [drafts, setDrafts] = useState<NewSlot[]>([{ ...EMPTY }])
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<AvailabilitySlot | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   const reload = () =>
-    availabilityApi.getMySlots().then((r) => setSlots(r.data.data)).catch(() => {})
+    availabilityApi
+      .getMySlots()
+      .then((r) => setSlots(r.data.data))
+      .catch(() => showToast({ title: 'Failed to load slots', variant: 'error' }))
 
-  useEffect(() => { reload() }, [])
+  useEffect(() => {
+    reload().finally(() => setLoading(false))
+  }, [])
 
   const byDate = slots.reduce<Record<string, AvailabilitySlot[]>>((acc, s) => {
     ;(acc[s.slotDate] ??= []).push(s)
@@ -52,6 +62,7 @@ export function AvailabilityCalendarPage() {
       setDrafts([{ ...EMPTY }])
       setSuccess(true)
       setTimeout(() => setSuccess(false), 3000)
+      showToast({ title: 'Slots saved', variant: 'success' })
       reload()
     } catch {
       setError('Failed to save slots — please try again.')
@@ -60,12 +71,30 @@ export function AvailabilityCalendarPage() {
     }
   }
 
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+    setDeleting(true)
+    try {
+      await availabilityApi.deleteSlot(deleteTarget.id)
+      setSlots((prev) => prev.filter((s) => s.id !== deleteTarget.id))
+      showToast({ title: 'Slot removed', variant: 'success' })
+    } catch {
+      showToast({ title: 'Failed to remove slot', variant: 'error' })
+    } finally {
+      setDeleting(false)
+      setDeleteTarget(null)
+    }
+  }
+
   return (
     <div className="space-y-6 max-w-3xl mx-auto">
       <h1 className="text-2xl font-bold">Interview Availability</h1>
 
-      {/* Existing slots */}
-      {Object.keys(byDate).length > 0 && (
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : Object.keys(byDate).length > 0 ? (
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Current Schedule</CardTitle>
@@ -78,19 +107,29 @@ export function AvailabilityCalendarPage() {
                   <p className="text-sm font-medium text-muted-foreground mb-2">{date}</p>
                   <div className="flex flex-wrap gap-2">
                     {daySlots.map((s) => (
-                      <Badge key={s.id} variant={s.booked ? 'secondary' : 'outline'}>
-                        {s.startTime} – {s.endTime}
-                        {s.booked && ' (booked)'}
-                      </Badge>
+                      <div key={s.id} className="flex items-center gap-1">
+                        <Badge variant={s.booked ? 'secondary' : 'outline'}>
+                          {s.startTime} – {s.endTime}
+                          {s.booked && ' (booked)'}
+                        </Badge>
+                        {!s.booked && (
+                          <button
+                            onClick={() => setDeleteTarget(s)}
+                            className="text-muted-foreground hover:text-destructive transition-colors"
+                            title="Remove slot"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </div>
                     ))}
                   </div>
                 </div>
               ))}
           </CardContent>
         </Card>
-      )}
+      ) : null}
 
-      {/* Add new slots */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Add Availability Slots</CardTitle>
@@ -151,6 +190,30 @@ export function AvailabilityCalendarPage() {
           </Button>
         </CardContent>
       </Card>
+
+      <Dialog open={deleteTarget !== null} onOpenChange={(o) => { if (!o) setDeleteTarget(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove slot?</DialogTitle>
+          </DialogHeader>
+          {deleteTarget && (
+            <p className="text-sm text-muted-foreground">
+              Remove{' '}
+              <span className="text-foreground font-medium">
+                {deleteTarget.slotDate} {deleteTarget.startTime}–{deleteTarget.endTime}
+              </span>
+              ? This cannot be undone.
+            </p>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+              {deleting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **FR-93** Recruiter availability calendar — delete slot with confirmation dialog, loading state, toasts
- **FR-94** Admin user management table — search by name/email, toasts on all mutations
- **FR-95** System metrics dashboard — pipeline summary stat cards (total apps, selected, rate), error toast
- **FR-96** Audit log viewer — email filter alongside entity filter, error toast
- **FR-97** AI model versioning toggle — activation confirmation dialog, toasts on all mutations
- **FR-98** Candidate result portal — loading spinner, error toasts on feedback fetch and download
- **FR-99** In-browser PDF viewer — page-by-page navigation, keyboard arrow key support (← →)

## Test plan
- [ ] Recruiter: add slots, verify delete button appears on unbooked slots, confirm dialog removes it
- [ ] Admin users: search filters by name and email; create/activate/deactivate show toasts
- [ ] Health dashboard: stat cards show totals; refresh button shows error toast on failure
- [ ] Audit log: entity type and email filters work independently and together; load more appends rows
- [ ] AI model: activating shows confirmation dialog; cancelling does nothing; confirming switches active badge
- [ ] Results: loading spinner shown while fetching; error toast on network failure
- [ ] PDF viewer: prev/next buttons disabled at boundaries; arrow keys navigate pages