### PR TITLE
feat(backend): candidate profile update API [FR-84 / hard filter]

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/CandidateProfileController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/CandidateProfileController.java
@@ -1,0 +1,37 @@
+package com.eaa.recruit.controller;
+
+import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.candidate.CandidateProfileRequest;
+import com.eaa.recruit.dto.candidate.CandidateProfileResponse;
+import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsCandidate;
+import com.eaa.recruit.service.CandidateProfileService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/candidates")
+@IsCandidate
+public class CandidateProfileController {
+
+    private final CandidateProfileService profileService;
+
+    public CandidateProfileController(CandidateProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<CandidateProfileResponse>> getProfile(
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+        return ResponseEntity.ok(ApiResponse.success(profileService.getProfile(principal.id())));
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<ApiResponse<CandidateProfileResponse>> updateProfile(
+            @AuthenticationPrincipal AuthenticatedUser principal,
+            @Valid @RequestBody CandidateProfileRequest request) {
+        return ResponseEntity.ok(ApiResponse.success("Profile updated", profileService.updateProfile(principal.id(), request)));
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/dto/candidate/CandidateProfileRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/candidate/CandidateProfileRequest.java
@@ -1,0 +1,26 @@
+package com.eaa.recruit.dto.candidate;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CandidateProfileRequest(
+        @NotNull @Min(100) @Max(250)
+        Integer heightCm,
+
+        @NotNull @Min(30) @Max(300)
+        Integer weightKg,
+
+        @NotNull @Size(min = 2, max = 100)
+        String degree,
+
+        @NotNull @Size(min = 2, max = 150)
+        String fieldOfStudy,
+
+        @NotNull @Min(1970) @Max(2100)
+        Integer graduationYear,
+
+        @Size(max = 20)
+        String phoneNumber
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/candidate/CandidateProfileResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/candidate/CandidateProfileResponse.java
@@ -1,0 +1,23 @@
+package com.eaa.recruit.dto.candidate;
+
+import com.eaa.recruit.entity.User;
+
+public record CandidateProfileResponse(
+        Integer heightCm,
+        Integer weightKg,
+        String  degree,
+        String  fieldOfStudy,
+        Integer graduationYear,
+        String  phoneNumber
+) {
+    public static CandidateProfileResponse from(User user) {
+        return new CandidateProfileResponse(
+                user.getHeightCm(),
+                user.getWeightKg(),
+                user.getDegree(),
+                user.getFieldOfStudy(),
+                user.getGraduationYear(),
+                user.getPhone()
+        );
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/entity/User.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/User.java
@@ -40,6 +40,12 @@ public class User extends BaseEntity {
     @Column(name = "degree", length = 100)
     private String degree;
 
+    @Column(name = "field_of_study", length = 150)
+    private String fieldOfStudy;
+
+    @Column(name = "graduation_year")
+    private Integer graduationYear;
+
     protected User() {}
 
     private User(String email, String passwordHash, Role role, String fullName) {
@@ -59,12 +65,24 @@ public class User extends BaseEntity {
     public String getFullName()     { return fullName; }
     public boolean isActive()       { return active; }
 
-    public String  getPhone()    { return phone; }
-    public Integer getHeightCm() { return heightCm; }
-    public Integer getWeightKg() { return weightKg; }
-    public String  getDegree()   { return degree; }
+    public String  getPhone()          { return phone; }
+    public Integer getHeightCm()       { return heightCm; }
+    public Integer getWeightKg()       { return weightKg; }
+    public String  getDegree()         { return degree; }
+    public String  getFieldOfStudy()   { return fieldOfStudy; }
+    public Integer getGraduationYear() { return graduationYear; }
 
     public void activate()                     { this.active = true; }
     public void deactivate()                   { this.active = false; }
     public void changePassword(String newHash) { this.passwordHash = newHash; }
+
+    public void updateProfile(Integer heightCm, Integer weightKg, String degree,
+                               String fieldOfStudy, Integer graduationYear, String phone) {
+        this.heightCm       = heightCm;
+        this.weightKg       = weightKg;
+        this.degree         = degree;
+        this.fieldOfStudy   = fieldOfStudy;
+        this.graduationYear = graduationYear;
+        this.phone          = phone;
+    }
 }

--- a/backend/src/main/java/com/eaa/recruit/service/CandidateProfileService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/CandidateProfileService.java
@@ -1,0 +1,41 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.candidate.CandidateProfileRequest;
+import com.eaa.recruit.dto.candidate.CandidateProfileResponse;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CandidateProfileService {
+
+    private final UserRepository userRepository;
+
+    public CandidateProfileService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public CandidateProfileResponse getProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+        return CandidateProfileResponse.from(user);
+    }
+
+    @Transactional
+    public CandidateProfileResponse updateProfile(Long userId, CandidateProfileRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+        user.updateProfile(
+                request.heightCm(),
+                request.weightKg(),
+                request.degree(),
+                request.fieldOfStudy(),
+                request.graduationYear(),
+                request.phoneNumber()
+        );
+        return CandidateProfileResponse.from(userRepository.save(user));
+    }
+}

--- a/backend/src/main/resources/db/migration/V11__add_candidate_profile_columns.sql
+++ b/backend/src/main/resources/db/migration/V11__add_candidate_profile_columns.sql
@@ -1,0 +1,10 @@
+-- V11: Candidate profile fields on users table (FR-84)
+-- height_cm, weight_kg, degree used by HardFilterService; field_of_study, graduation_year, phone for profile display
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS phone           VARCHAR(20),
+    ADD COLUMN IF NOT EXISTS height_cm       INTEGER,
+    ADD COLUMN IF NOT EXISTS weight_kg       INTEGER,
+    ADD COLUMN IF NOT EXISTS degree          VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS field_of_study  VARCHAR(150),
+    ADD COLUMN IF NOT EXISTS graduation_year INTEGER;

--- a/backend/src/test/java/com/eaa/recruit/service/CandidateProfileServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/CandidateProfileServiceTest.java
@@ -1,0 +1,100 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.candidate.CandidateProfileRequest;
+import com.eaa.recruit.dto.candidate.CandidateProfileResponse;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.ResourceNotFoundException;
+import com.eaa.recruit.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CandidateProfileServiceTest {
+
+    @Mock UserRepository userRepository;
+
+    CandidateProfileService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CandidateProfileService(userRepository);
+    }
+
+    private User blankCandidate() {
+        return User.create("candidate@eaa.com", "hash", Role.CANDIDATE, "Test User");
+    }
+
+    @Test
+    void getProfile_returnsCurrentValues() {
+        User user = blankCandidate();
+        user.updateProfile(175, 70, "Bachelor", "CS", 2020, "+1234");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        CandidateProfileResponse resp = service.getProfile(1L);
+
+        assertThat(resp.heightCm()).isEqualTo(175);
+        assertThat(resp.weightKg()).isEqualTo(70);
+        assertThat(resp.degree()).isEqualTo("Bachelor");
+        assertThat(resp.fieldOfStudy()).isEqualTo("CS");
+        assertThat(resp.graduationYear()).isEqualTo(2020);
+        assertThat(resp.phoneNumber()).isEqualTo("+1234");
+    }
+
+    @Test
+    void getProfile_nullFields_whenProfileNotYetSet() {
+        when(userRepository.findById(2L)).thenReturn(Optional.of(blankCandidate()));
+
+        CandidateProfileResponse resp = service.getProfile(2L);
+
+        assertThat(resp.heightCm()).isNull();
+        assertThat(resp.degree()).isNull();
+    }
+
+    @Test
+    void getProfile_throwsNotFound_whenUserMissing() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getProfile(99L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void updateProfile_persistsAllFields() {
+        User user = blankCandidate();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        CandidateProfileRequest req = new CandidateProfileRequest(180, 75, "Master", "Aviation", 2018, "+9999");
+        CandidateProfileResponse resp = service.updateProfile(1L, req);
+
+        assertThat(resp.heightCm()).isEqualTo(180);
+        assertThat(resp.weightKg()).isEqualTo(75);
+        assertThat(resp.degree()).isEqualTo("Master");
+        assertThat(resp.fieldOfStudy()).isEqualTo("Aviation");
+        assertThat(resp.graduationYear()).isEqualTo(2018);
+        assertThat(resp.phoneNumber()).isEqualTo("+9999");
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void updateProfile_throwsNotFound_whenUserMissing() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        CandidateProfileRequest req = new CandidateProfileRequest(175, 70, "Bachelor", "CS", 2020, null);
+        assertThatThrownBy(() -> service.updateProfile(99L, req))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(userRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- Flyway V11 migration adds `phone`, `height_cm`, `weight_kg`, `degree`, `field_of_study`, `graduation_year` columns to `users` — these were mapped in the `User` entity but absent from the DB, which would have caused hard-filter failures at runtime
- `User` entity extended with `fieldOfStudy`, `graduationYear` fields and `updateProfile()` mutator
- `GET /api/v1/candidates/profile` — returns current profile (all null if not yet filled)
- `PUT /api/v1/candidates/profile` — validates and persists all profile fields; secured with `@IsCandidate`
- 5 unit tests covering get, null fields, not-found, update, and update-not-found paths

## Test plan
- [ ] `PUT /api/v1/candidates/profile` with valid body returns updated profile
- [ ] `GET /api/v1/candidates/profile` reflects persisted values across requests
- [ ] Missing required fields (heightCm, degree, etc.) return 400 with field errors
- [ ] Non-candidate JWT receives 403
- [ ] Hard filter correctly evaluates `height_cm`, `weight_kg`, `degree` after profile is saved