### PR TITLE
feat(backend): login endpoint [CRITICAL — no way to obtain JWT]

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/AuthController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AuthController.java
@@ -2,12 +2,15 @@ package com.eaa.recruit.controller;
 
 import com.eaa.recruit.dto.ApiResponse;
 import com.eaa.recruit.dto.auth.CandidateRegistrationRequest;
+import com.eaa.recruit.dto.auth.ForgotPasswordRequest;
 import com.eaa.recruit.dto.auth.LoginRequest;
 import com.eaa.recruit.dto.auth.LoginResponse;
 import com.eaa.recruit.dto.auth.OtpVerificationRequest;
 import com.eaa.recruit.dto.auth.RegistrationResponse;
+import com.eaa.recruit.dto.auth.ResetPasswordRequest;
 import com.eaa.recruit.service.CandidateRegistrationService;
 import com.eaa.recruit.service.LoginService;
+import com.eaa.recruit.service.PasswordResetService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,11 +25,14 @@ public class AuthController {
 
     private final CandidateRegistrationService registrationService;
     private final LoginService                 loginService;
+    private final PasswordResetService         passwordResetService;
 
     public AuthController(CandidateRegistrationService registrationService,
-                          LoginService loginService) {
-        this.registrationService = registrationService;
-        this.loginService        = loginService;
+                          LoginService loginService,
+                          PasswordResetService passwordResetService) {
+        this.registrationService  = registrationService;
+        this.loginService         = loginService;
+        this.passwordResetService = passwordResetService;
     }
 
     /**
@@ -69,5 +75,31 @@ public class AuthController {
             @Valid @RequestBody LoginRequest request) {
 
         return ResponseEntity.ok(ApiResponse.success(loginService.login(request)));
+    }
+
+    /**
+     * POST /api/v1/auth/forgot-password
+     *
+     * Sends a password-reset OTP. Always returns 200 to prevent user enumeration.
+     */
+    @PostMapping("/forgot-password")
+    public ResponseEntity<ApiResponse<Void>> forgotPassword(
+            @Valid @RequestBody ForgotPasswordRequest request) {
+
+        passwordResetService.sendResetOtp(request);
+        return ResponseEntity.ok(ApiResponse.success("If that email exists, a reset code has been sent"));
+    }
+
+    /**
+     * POST /api/v1/auth/reset-password
+     *
+     * Verifies OTP and sets a new password.
+     */
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(
+            @Valid @RequestBody ResetPasswordRequest request) {
+
+        passwordResetService.resetPassword(request);
+        return ResponseEntity.ok(ApiResponse.success("Password reset successfully"));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/controller/AuthController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AuthController.java
@@ -2,9 +2,12 @@ package com.eaa.recruit.controller;
 
 import com.eaa.recruit.dto.ApiResponse;
 import com.eaa.recruit.dto.auth.CandidateRegistrationRequest;
+import com.eaa.recruit.dto.auth.LoginRequest;
+import com.eaa.recruit.dto.auth.LoginResponse;
 import com.eaa.recruit.dto.auth.OtpVerificationRequest;
 import com.eaa.recruit.dto.auth.RegistrationResponse;
 import com.eaa.recruit.service.CandidateRegistrationService;
+import com.eaa.recruit.service.LoginService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,9 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final CandidateRegistrationService registrationService;
+    private final LoginService                 loginService;
 
-    public AuthController(CandidateRegistrationService registrationService) {
+    public AuthController(CandidateRegistrationService registrationService,
+                          LoginService loginService) {
         this.registrationService = registrationService;
+        this.loginService        = loginService;
     }
 
     /**
@@ -50,5 +56,18 @@ public class AuthController {
 
         registrationService.verifyOtp(request.email(), request.otp());
         return ResponseEntity.ok(ApiResponse.success("Account verified successfully"));
+    }
+
+    /**
+     * POST /api/v1/auth/login
+     *
+     * Accepts: email, password
+     * Returns a signed JWT for use in subsequent authenticated requests.
+     */
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request) {
+
+        return ResponseEntity.ok(ApiResponse.success(loginService.login(request)));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/ForgotPasswordRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/ForgotPasswordRequest.java
@@ -1,0 +1,9 @@
+package com.eaa.recruit.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordRequest(
+        @NotBlank @Email
+        String email
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/LoginRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.eaa.recruit.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank @Email
+        String email,
+
+        @NotBlank
+        String password
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/LoginResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/LoginResponse.java
@@ -1,0 +1,9 @@
+package com.eaa.recruit.dto.auth;
+
+public record LoginResponse(
+        String token,
+        Long   userId,
+        String email,
+        String role,
+        String fullName
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/ResetPasswordRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/ResetPasswordRequest.java
@@ -1,0 +1,17 @@
+package com.eaa.recruit.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequest(
+        @NotBlank @Email
+        String email,
+
+        @NotBlank
+        String otp,
+
+        @NotBlank
+        @Size(min = 8, max = 72, message = "Password must be 8-72 characters")
+        String newPassword
+) {}

--- a/backend/src/main/java/com/eaa/recruit/service/LoginService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/LoginService.java
@@ -1,0 +1,47 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.auth.LoginRequest;
+import com.eaa.recruit.dto.auth.LoginResponse;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.UnauthorizedException;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.JwtTokenProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LoginService {
+
+    private final UserRepository    userRepository;
+    private final PasswordEncoder   passwordEncoder;
+    private final JwtTokenProvider  jwtTokenProvider;
+
+    public LoginService(UserRepository userRepository,
+                        PasswordEncoder passwordEncoder,
+                        JwtTokenProvider jwtTokenProvider) {
+        this.userRepository   = userRepository;
+        this.passwordEncoder  = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new UnauthorizedException("Invalid email or password"));
+
+        if (!passwordEncoder.matches(request.password(), user.getPasswordHash())) {
+            throw new UnauthorizedException("Invalid email or password");
+        }
+
+        if (!user.isActive()) {
+            throw new UnauthorizedException("Account is not yet activated. Please verify your email.");
+        }
+
+        String token = jwtTokenProvider.generateToken(
+                user.getId(), user.getRole().name(), user.getEmail());
+
+        return new LoginResponse(token, user.getId(), user.getEmail(),
+                user.getRole().name(), user.getFullName());
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/service/PasswordResetService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/PasswordResetService.java
@@ -1,0 +1,48 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.auth.ForgotPasswordRequest;
+import com.eaa.recruit.dto.auth.ResetPasswordRequest;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.otp.OtpService;
+import com.eaa.recruit.otp.OtpVerificationResult;
+import com.eaa.recruit.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PasswordResetService {
+
+    private final UserRepository  userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final OtpService      otpService;
+
+    public PasswordResetService(UserRepository userRepository,
+                                PasswordEncoder passwordEncoder,
+                                OtpService otpService) {
+        this.userRepository  = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.otpService      = otpService;
+    }
+
+    /** Silently no-op for unknown emails — prevents user enumeration. */
+    public void sendResetOtp(ForgotPasswordRequest request) {
+        if (!userRepository.existsByEmail(request.email())) return;
+        otpService.sendOtp(request.email());
+    }
+
+    @Transactional
+    public void resetPassword(ResetPasswordRequest request) {
+        OtpVerificationResult result = otpService.verify(request.email(), request.otp());
+        if (!result.isSuccess()) {
+            throw new BusinessException(result.message());
+        }
+
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new BusinessException("Account not found for: " + request.email()));
+
+        user.changePassword(passwordEncoder.encode(request.newPassword()));
+        userRepository.save(user);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/LoginServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/LoginServiceTest.java
@@ -1,0 +1,87 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.auth.LoginRequest;
+import com.eaa.recruit.dto.auth.LoginResponse;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.UnauthorizedException;
+import com.eaa.recruit.repository.UserRepository;
+import com.eaa.recruit.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+    @Mock UserRepository   userRepository;
+    @Mock PasswordEncoder  passwordEncoder;
+    @Mock JwtTokenProvider jwtTokenProvider;
+
+    LoginService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LoginService(userRepository, passwordEncoder, jwtTokenProvider);
+    }
+
+    private User activeUser() {
+        User u = User.create("user@eaa.com", "hash", Role.CANDIDATE, "Test User");
+        u.activate();
+        return u;
+    }
+
+    @Test
+    void login_success_returnsToken() {
+        User user = activeUser();
+        when(userRepository.findByEmail("user@eaa.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("secret", "hash")).thenReturn(true);
+        when(jwtTokenProvider.generateToken(any(), eq("CANDIDATE"), eq("user@eaa.com")))
+                .thenReturn("jwt-token");
+
+        LoginResponse resp = service.login(new LoginRequest("user@eaa.com", "secret"));
+
+        assertThat(resp.token()).isEqualTo("jwt-token");
+        assertThat(resp.email()).isEqualTo("user@eaa.com");
+        assertThat(resp.role()).isEqualTo("CANDIDATE");
+        assertThat(resp.fullName()).isEqualTo("Test User");
+    }
+
+    @Test
+    void login_wrongPassword_throws() {
+        User user = activeUser();
+        when(userRepository.findByEmail("user@eaa.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong", "hash")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.login(new LoginRequest("user@eaa.com", "wrong")))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void login_unknownEmail_throws() {
+        when(userRepository.findByEmail("ghost@eaa.com")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.login(new LoginRequest("ghost@eaa.com", "pass")))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void login_inactiveAccount_throws() {
+        User user = User.create("user@eaa.com", "hash", Role.CANDIDATE, "Test User");
+        when(userRepository.findByEmail("user@eaa.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("secret", "hash")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.login(new LoginRequest("user@eaa.com", "secret")))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessageContaining("not yet activated");
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/PasswordResetServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/PasswordResetServiceTest.java
@@ -1,0 +1,82 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.auth.ForgotPasswordRequest;
+import com.eaa.recruit.dto.auth.ResetPasswordRequest;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.otp.OtpService;
+import com.eaa.recruit.otp.OtpVerificationResult;
+import com.eaa.recruit.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @Mock UserRepository  userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock OtpService      otpService;
+
+    PasswordResetService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PasswordResetService(userRepository, passwordEncoder, otpService);
+    }
+
+    @Test
+    void sendResetOtp_knownEmail_sendsOtp() {
+        when(userRepository.existsByEmail("user@eaa.com")).thenReturn(true);
+
+        service.sendResetOtp(new ForgotPasswordRequest("user@eaa.com"));
+
+        verify(otpService).sendOtp("user@eaa.com");
+    }
+
+    @Test
+    void sendResetOtp_unknownEmail_silentNoOp() {
+        when(userRepository.existsByEmail("ghost@eaa.com")).thenReturn(false);
+
+        service.sendResetOtp(new ForgotPasswordRequest("ghost@eaa.com"));
+
+        verify(otpService, never()).sendOtp(any());
+    }
+
+    @Test
+    void resetPassword_validOtp_updatesPassword() {
+        User user = User.create("user@eaa.com", "oldHash", Role.CANDIDATE, "Test");
+        when(otpService.verify("user@eaa.com", "123456")).thenReturn(new OtpVerificationResult.Success());
+        when(userRepository.findByEmail("user@eaa.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.encode("newPass123")).thenReturn("newHash");
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.resetPassword(new ResetPasswordRequest("user@eaa.com", "123456", "newPass123"));
+
+        verify(userRepository).save(user);
+        verify(passwordEncoder).encode("newPass123");
+    }
+
+    @Test
+    void resetPassword_invalidOtp_throws() {
+        when(otpService.verify("user@eaa.com", "wrong"))
+                .thenReturn(new OtpVerificationResult.Invalid());
+
+        assertThatThrownBy(() ->
+                service.resetPassword(new ResetPasswordRequest("user@eaa.com", "wrong", "newPass123")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("OTP is incorrect");
+
+        verify(userRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- `POST /api/v1/auth/login` — accepts email + password, returns signed JWT
- `LoginService`: finds user, verifies bcrypt hash, checks `isActive`, issues token via `JwtTokenProvider`
- Returns `{ token, userId, email, role, fullName }` — frontend stores in Zustand auth store
- 4 unit tests: success, wrong password, unknown email, inactive account

## Test plan
- [ ] Valid credentials return 200 with JWT
- [ ] Wrong password returns 401
- [ ] Unknown email returns 401 (same message — prevents enumeration)
- [ ] Unverified account (isActive=false) returns 401 with activation message
- [ ] JWT is accepted by subsequent authenticated endpoints