### PR TITLE
feat(backend): password reset flow

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/AuthController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AuthController.java
@@ -2,12 +2,15 @@ package com.eaa.recruit.controller;
 
 import com.eaa.recruit.dto.ApiResponse;
 import com.eaa.recruit.dto.auth.CandidateRegistrationRequest;
+import com.eaa.recruit.dto.auth.ForgotPasswordRequest;
 import com.eaa.recruit.dto.auth.LoginRequest;
 import com.eaa.recruit.dto.auth.LoginResponse;
 import com.eaa.recruit.dto.auth.OtpVerificationRequest;
 import com.eaa.recruit.dto.auth.RegistrationResponse;
+import com.eaa.recruit.dto.auth.ResetPasswordRequest;
 import com.eaa.recruit.service.CandidateRegistrationService;
 import com.eaa.recruit.service.LoginService;
+import com.eaa.recruit.service.PasswordResetService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,11 +25,14 @@ public class AuthController {
 
     private final CandidateRegistrationService registrationService;
     private final LoginService                 loginService;
+    private final PasswordResetService         passwordResetService;
 
     public AuthController(CandidateRegistrationService registrationService,
-                          LoginService loginService) {
-        this.registrationService = registrationService;
-        this.loginService        = loginService;
+                          LoginService loginService,
+                          PasswordResetService passwordResetService) {
+        this.registrationService  = registrationService;
+        this.loginService         = loginService;
+        this.passwordResetService = passwordResetService;
     }
 
     /**
@@ -69,5 +75,31 @@ public class AuthController {
             @Valid @RequestBody LoginRequest request) {
 
         return ResponseEntity.ok(ApiResponse.success(loginService.login(request)));
+    }
+
+    /**
+     * POST /api/v1/auth/forgot-password
+     *
+     * Sends a password-reset OTP. Always returns 200 to prevent user enumeration.
+     */
+    @PostMapping("/forgot-password")
+    public ResponseEntity<ApiResponse<Void>> forgotPassword(
+            @Valid @RequestBody ForgotPasswordRequest request) {
+
+        passwordResetService.sendResetOtp(request);
+        return ResponseEntity.ok(ApiResponse.success("If that email exists, a reset code has been sent"));
+    }
+
+    /**
+     * POST /api/v1/auth/reset-password
+     *
+     * Verifies OTP and sets a new password.
+     */
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(
+            @Valid @RequestBody ResetPasswordRequest request) {
+
+        passwordResetService.resetPassword(request);
+        return ResponseEntity.ok(ApiResponse.success("Password reset successfully"));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/ForgotPasswordRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/ForgotPasswordRequest.java
@@ -1,0 +1,9 @@
+package com.eaa.recruit.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordRequest(
+        @NotBlank @Email
+        String email
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/auth/ResetPasswordRequest.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/auth/ResetPasswordRequest.java
@@ -1,0 +1,17 @@
+package com.eaa.recruit.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequest(
+        @NotBlank @Email
+        String email,
+
+        @NotBlank
+        String otp,
+
+        @NotBlank
+        @Size(min = 8, max = 72, message = "Password must be 8-72 characters")
+        String newPassword
+) {}

--- a/backend/src/main/java/com/eaa/recruit/service/PasswordResetService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/PasswordResetService.java
@@ -1,0 +1,48 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.auth.ForgotPasswordRequest;
+import com.eaa.recruit.dto.auth.ResetPasswordRequest;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.otp.OtpService;
+import com.eaa.recruit.otp.OtpVerificationResult;
+import com.eaa.recruit.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PasswordResetService {
+
+    private final UserRepository  userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final OtpService      otpService;
+
+    public PasswordResetService(UserRepository userRepository,
+                                PasswordEncoder passwordEncoder,
+                                OtpService otpService) {
+        this.userRepository  = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.otpService      = otpService;
+    }
+
+    /** Silently no-op for unknown emails — prevents user enumeration. */
+    public void sendResetOtp(ForgotPasswordRequest request) {
+        if (!userRepository.existsByEmail(request.email())) return;
+        otpService.sendOtp(request.email());
+    }
+
+    @Transactional
+    public void resetPassword(ResetPasswordRequest request) {
+        OtpVerificationResult result = otpService.verify(request.email(), request.otp());
+        if (!result.isSuccess()) {
+            throw new BusinessException(result.message());
+        }
+
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new BusinessException("Account not found for: " + request.email()));
+
+        user.changePassword(passwordEncoder.encode(request.newPassword()));
+        userRepository.save(user);
+    }
+}

--- a/backend/src/test/java/com/eaa/recruit/service/PasswordResetServiceTest.java
+++ b/backend/src/test/java/com/eaa/recruit/service/PasswordResetServiceTest.java
@@ -1,0 +1,82 @@
+package com.eaa.recruit.service;
+
+import com.eaa.recruit.dto.auth.ForgotPasswordRequest;
+import com.eaa.recruit.dto.auth.ResetPasswordRequest;
+import com.eaa.recruit.entity.Role;
+import com.eaa.recruit.entity.User;
+import com.eaa.recruit.exception.BusinessException;
+import com.eaa.recruit.otp.OtpService;
+import com.eaa.recruit.otp.OtpVerificationResult;
+import com.eaa.recruit.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @Mock UserRepository  userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock OtpService      otpService;
+
+    PasswordResetService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PasswordResetService(userRepository, passwordEncoder, otpService);
+    }
+
+    @Test
+    void sendResetOtp_knownEmail_sendsOtp() {
+        when(userRepository.existsByEmail("user@eaa.com")).thenReturn(true);
+
+        service.sendResetOtp(new ForgotPasswordRequest("user@eaa.com"));
+
+        verify(otpService).sendOtp("user@eaa.com");
+    }
+
+    @Test
+    void sendResetOtp_unknownEmail_silentNoOp() {
+        when(userRepository.existsByEmail("ghost@eaa.com")).thenReturn(false);
+
+        service.sendResetOtp(new ForgotPasswordRequest("ghost@eaa.com"));
+
+        verify(otpService, never()).sendOtp(any());
+    }
+
+    @Test
+    void resetPassword_validOtp_updatesPassword() {
+        User user = User.create("user@eaa.com", "oldHash", Role.CANDIDATE, "Test");
+        when(otpService.verify("user@eaa.com", "123456")).thenReturn(new OtpVerificationResult.Success());
+        when(userRepository.findByEmail("user@eaa.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.encode("newPass123")).thenReturn("newHash");
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.resetPassword(new ResetPasswordRequest("user@eaa.com", "123456", "newPass123"));
+
+        verify(userRepository).save(user);
+        verify(passwordEncoder).encode("newPass123");
+    }
+
+    @Test
+    void resetPassword_invalidOtp_throws() {
+        when(otpService.verify("user@eaa.com", "wrong"))
+                .thenReturn(new OtpVerificationResult.Invalid());
+
+        assertThatThrownBy(() ->
+                service.resetPassword(new ResetPasswordRequest("user@eaa.com", "wrong", "newPass123")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("OTP is incorrect");
+
+        verify(userRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- `POST /api/v1/auth/forgot-password` — sends OTP to email; returns 200 for unknown emails (prevents user enumeration)
- `POST /api/v1/auth/reset-password` — verifies OTP via existing `OtpService`, sets new bcrypt-hashed password
- `PasswordResetService` reuses the same OTP Redis cache as the registration flow
- 4 unit tests: known email sends OTP, unknown email is silent no-op, valid OTP resets password, invalid OTP throws

## Test plan
- [ ] `POST /forgot-password` with known email triggers OTP (check mock adapter log)
- [ ] `POST /forgot-password` with unknown email returns 200 with no OTP sent
- [ ] `POST /reset-password` with correct OTP updates password; old password no longer works
- [ ] `POST /reset-password` with wrong/expired OTP returns 400