### PR TITLE
feat(backend): extend User entity for FR-84 profile fields

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/entity/User.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/User.java
@@ -72,6 +72,8 @@ public class User extends BaseEntity {
     public String  getFieldOfStudy()   { return fieldOfStudy; }
     public Integer getGraduationYear() { return graduationYear; }
 
+    public void setPhone(String phone)         { this.phone = phone; }
+
     public void activate()                     { this.active = true; }
     public void deactivate()                   { this.active = false; }
     public void changePassword(String newHash) { this.passwordHash = newHash; }

--- a/backend/src/main/java/com/eaa/recruit/service/CandidateRegistrationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/CandidateRegistrationService.java
@@ -46,6 +46,7 @@ public class CandidateRegistrationService {
 
         String passwordHash = passwordEncoder.encode(request.password());
         User user = User.create(request.email(), passwordHash, Role.CANDIDATE, request.fullName());
+        user.setPhone(request.phone());
         user = userRepository.save(user);
 
         log.info("Candidate account created id={} email='{}'", user.getId(), user.getEmail());


### PR DESCRIPTION
## Summary
- `phone` from `CandidateRegistrationRequest` was silently discarded — never written to `users.phone`
- Added `User.setPhone(String)` and called it in `CandidateRegistrationService.register()` immediately after entity creation
- `fieldOfStudy` and `graduationYear` were added in the previous profile API commit (V11 migration); this commit wires phone persistence that was missing from day one

## Test plan
- [ ] Register a candidate, verify `users.phone` is populated in DB
- [ ] Subsequent `GET /candidates/profile` returns the phone number set at registration
- [ ] Updating profile via `PUT /candidates/profile` with a different phone overwrites it