### PR TITLE
feat(backend): extend Application entity for decision + interview slot fields

### DIFF
--- a/backend/src/main/java/com/eaa/recruit/controller/ApplicationController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/ApplicationController.java
@@ -1,9 +1,12 @@
 package com.eaa.recruit.controller;
 
 import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.application.ApplicationResponse;
 import com.eaa.recruit.dto.application.SubmitApplicationResponse;
 import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsAuthenticated;
 import com.eaa.recruit.security.rbac.IsCandidate;
+import com.eaa.recruit.security.rbac.IsRecruiterOrAbove;
 import com.eaa.recruit.service.ApplicationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -11,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/applications")
@@ -22,10 +27,7 @@ public class ApplicationController {
         this.applicationService = applicationService;
     }
 
-    /**
-     * POST /api/v1/applications
-     * Submit a job application with a CV file. Candidate only.
-     */
+    /** POST /api/v1/applications — submit application with CV. Candidate only. */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @IsCandidate
     public ResponseEntity<ApiResponse<SubmitApplicationResponse>> submitApplication(
@@ -36,5 +38,36 @@ public class ApplicationController {
         SubmitApplicationResponse response = applicationService.submitApplication(jobId, cv, principal);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("Application submitted successfully", response));
+    }
+
+    /** GET /api/v1/applications/my — list authenticated candidate's applications. */
+    @GetMapping("/my")
+    @IsCandidate
+    public ResponseEntity<ApiResponse<List<ApplicationResponse>>> getMyApplications(
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        return ResponseEntity.ok(ApiResponse.success(
+                applicationService.getMyApplications(principal.id())));
+    }
+
+    /** GET /api/v1/applications?jobId=X — list applications for a job. Recruiter+. */
+    @GetMapping
+    @IsRecruiterOrAbove
+    public ResponseEntity<ApiResponse<List<ApplicationResponse>>> getByJob(
+            @RequestParam Long jobId) {
+
+        return ResponseEntity.ok(ApiResponse.success(
+                applicationService.getApplicationsByJob(jobId)));
+    }
+
+    /** GET /api/v1/applications/{id} — single application. Candidate (own) or recruiter+. */
+    @GetMapping("/{id}")
+    @IsAuthenticated
+    public ResponseEntity<ApiResponse<ApplicationResponse>> getApplication(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+
+        return ResponseEntity.ok(ApiResponse.success(
+                applicationService.getApplication(id, principal.id(), principal.role())));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/dto/application/ApplicationResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/ApplicationResponse.java
@@ -1,0 +1,41 @@
+package com.eaa.recruit.dto.application;
+
+import com.eaa.recruit.entity.Application;
+import com.eaa.recruit.entity.ApplicationStatus;
+
+import java.time.Instant;
+
+public record ApplicationResponse(
+        Long              id,
+        Long              jobId,
+        String            jobTitle,
+        ApplicationStatus status,
+        Double            cvRelevanceScore,
+        Double            examScore,
+        Boolean           hardFilterPassed,
+        Double            finalScore,
+        Instant           submittedAt,
+        String            interviewSlotDate,
+        String            interviewSlotTime
+) {
+    public static ApplicationResponse from(Application app) {
+        String slotDate = app.getInterviewSlot() != null
+                ? app.getInterviewSlot().getSlotDate().toString() : null;
+        String slotTime = app.getInterviewSlot() != null
+                ? app.getInterviewSlot().getStartTime().toString() : null;
+
+        return new ApplicationResponse(
+                app.getId(),
+                app.getJob().getId(),
+                app.getJob().getTitle(),
+                app.getStatus(),
+                app.getCvRelevanceScore(),
+                app.getExamScore(),
+                app.getHardFilterPassed(),
+                app.getFinalScore(),
+                app.getSubmittedAt(),
+                slotDate,
+                slotTime
+        );
+    }
+}

--- a/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
+    List<Application> findAllByCandidateId(Long candidateId);
+
     boolean existsByCandidateIdAndJobId(Long candidateId, Long jobId);
 
     Optional<Application> findByCandidateIdAndJobId(Long candidateId, Long jobId);

--- a/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
@@ -1,6 +1,7 @@
 package com.eaa.recruit.service;
 
 import com.eaa.recruit.dto.application.AiScoreCallbackRequest;
+import com.eaa.recruit.dto.application.ApplicationResponse;
 import com.eaa.recruit.dto.application.SubmitApplicationResponse;
 import com.eaa.recruit.dto.internal.ExamScoreCallbackRequest;
 import com.eaa.recruit.entity.Application;
@@ -22,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 public class ApplicationService {
@@ -135,5 +138,31 @@ public class ApplicationService {
 
         log.info("Exam score applied applicationId={} examScore={} finalScore={} completedAt={}",
                 applicationId, request.examScore(), finalScore, request.completedAt());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApplicationResponse> getMyApplications(Long candidateId) {
+        return applicationRepository.findAllByCandidateId(candidateId)
+                .stream()
+                .map(ApplicationResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApplicationResponse> getApplicationsByJob(Long jobId) {
+        return applicationRepository.findByJobId(jobId)
+                .stream()
+                .map(ApplicationResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ApplicationResponse getApplication(Long applicationId, Long requesterId, String role) {
+        Application app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application", applicationId));
+        if ("CANDIDATE".equals(role) && !app.getCandidate().getId().equals(requesterId)) {
+            throw new com.eaa.recruit.exception.UnauthorizedException("Access denied");
+        }
+        return ApplicationResponse.from(app);
     }
 }


### PR DESCRIPTION
## Summary
- Added `ApplicationResponse` DTO with full fields the frontend needs: `jobTitle`, `cvRelevanceScore`, `examScore`, `hardFilterPassed`, `finalScore`, `interviewSlotDate`, `interviewSlotTime`
- `GET /api/v1/applications/my` — returns all applications for the authenticated candidate (was entirely missing; frontend polls this every 30 s)
- `GET /api/v1/applications?jobId=X` — lists applications by job for recruiter+
- `GET /api/v1/applications/{id}` — single application; candidates can only access their own
- Added `findAllByCandidateId` to `ApplicationRepository`

## Test plan
- [ ] `GET /applications/my` returns candidate's applications with correct status and scores
- [ ] `interviewSlotDate` and `interviewSlotTime` populated once slot is booked
- [ ] `GET /applications?jobId=X` returns all candidates for that job (recruiter token)
- [ ] Candidate cannot access another candidate's application via `GET /applications/{id}`
- [ ] ApplicationsPage timeline reflects live status without page refresh