### PR TITLE
infra: Dockerfiles for all four services

### DIFF
--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.11-slim AS runtime
 WORKDIR /app
 
+ENV PYTHONUNBUFFERED=1
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         libgl1 \
@@ -8,7 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+ && python -m spacy download en_core_web_sm
 
 COPY src/ src/
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /workspace
 
 COPY gradle/ gradle/
 COPY gradlew gradle.properties settings.gradle build.gradle ./
-RUN chmod +x gradlew && ./gradlew --version --no-daemon
+# Strip Windows-local JAVA_HOME path — eclipse-temurin image sets it correctly
+RUN chmod +x gradlew \
+ && sed -i '/org\.gradle\.java\.home/d' gradle.properties \
+ && ./gradlew --version --no-daemon
 
 COPY src/ src/
 RUN ./gradlew bootJar --no-daemon -x test

--- a/exam-engine/Dockerfile
+++ b/exam-engine/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM golang:1.23-alpine AS build
+FROM golang:1.24-alpine AS build
 WORKDIR /src
 
 COPY go.mod go.sum ./
@@ -9,7 +9,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/exam-engine ./cmd/server
 
 # ── Runtime stage ────────────────────────────────────────────────────────────
-FROM alpine:3.20 AS runtime
+FROM alpine:3.21 AS runtime
 WORKDIR /app
 
 RUN addgroup -S app && adduser -S app -G app && apk add --no-cache ca-certificates

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Summary

- **exam-engine**: `golang:1.23` → `1.24` (matches `go.mod` toolchain); `alpine:3.20` → `3.21`
- **backend**: strips `org.gradle.java.home=C:/Program Files/...` from `gradle.properties` at build time — Windows path breaks Alpine
- **ai-service**: downloads `en_core_web_sm` spaCy model after pip install (required by `nlp_pipeline.py`); adds `PYTHONUNBUFFERED=1`
- **frontend**: `node:20` → `node:22` — React 19, Vite 8, and TypeScript 6 require Node ≥ 22

## Test plan

- [ ] `docker build -t exam-engine ./exam-engine` — clean build, binary runs
- [ ] `docker build -t backend ./backend` — `bootJar` succeeds without JAVA_HOME error
- [ ] `docker build -t ai-service ./ai-service` — spaCy model downloads; uvicorn starts
- [ ] `docker build -t frontend ./frontend` — Vite build succeeds; nginx serves SPA with `/api` proxy
- [ ] `docker compose up` — all services healthy