### PR TITLE
feat(backend): list endpoints + bootable Docker stack

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
 # Use the pre-packaged Gradle image — avoids the wrapper downloading gradle-8.13-bin.zip
 # which times out due to the wrapper's hardcoded 10s socket timeout.
-FROM gradle:8.13-jdk23-alpine AS build
+FROM gradle:8.13-jdk21-alpine AS build
 WORKDIR /workspace
 
 COPY settings.gradle build.gradle ./
@@ -11,11 +11,14 @@ COPY src/ src/
 RUN gradle bootJar --no-daemon -x test
 
 # ── Runtime stage ────────────────────────────────────────────────────────────
-FROM eclipse-temurin:23-jre-alpine AS runtime
+FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -S app && adduser -S app -G app \
+    && mkdir -p /app/cv-uploads /app/xai-reports \
+    && chown -R app:app /app
 COPY --from=build /workspace/build/libs/*.jar app.jar
+RUN chown app:app /app/app.jar
 
 USER app
 EXPOSE 8080

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(23)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -43,6 +43,9 @@ dependencies {
 
     // PostgreSQL driver
     runtimeOnly 'org.postgresql:postgresql'
+
+    // Flyway — runs db/migration/V*.sql on startup
+    implementation 'org.flywaydb:flyway-core'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/eaa/recruit/controller/AdminUserController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/AdminUserController.java
@@ -1,9 +1,11 @@
 package com.eaa.recruit.controller;
 
 import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.admin.AdminUserResponse;
 import com.eaa.recruit.dto.admin.CreateRecruiterRequest;
 import com.eaa.recruit.dto.admin.RecruiterCreatedResponse;
 import com.eaa.recruit.dto.admin.UserStatusRequest;
+import com.eaa.recruit.entity.Role;
 import com.eaa.recruit.security.AuthenticatedUser;
 import com.eaa.recruit.security.rbac.IsAdmin;
 import com.eaa.recruit.service.RecruiterAdminService;
@@ -13,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/admin/users")
@@ -57,5 +61,15 @@ public class AdminUserController {
                 ? "User activated successfully"
                 : "User deactivated successfully";
         return ResponseEntity.ok(ApiResponse.success(msg));
+    }
+
+    /**
+     * GET /api/v1/admin/users
+     * Lists all users, newest first. Optional ?role=ADMIN|RECRUITER|CANDIDATE filter.
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AdminUserResponse>>> listUsers(
+            @RequestParam(value = "role", required = false) Role role) {
+        return ResponseEntity.ok(ApiResponse.success(recruiterAdminService.listUsers(role)));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/controller/ApplicationController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/ApplicationController.java
@@ -1,6 +1,7 @@
 package com.eaa.recruit.controller;
 
 import com.eaa.recruit.dto.ApiResponse;
+import com.eaa.recruit.dto.application.ApplicationResponse;
 import com.eaa.recruit.dto.application.SubmitApplicationResponse;
 import com.eaa.recruit.security.AuthenticatedUser;
 import com.eaa.recruit.security.rbac.IsCandidate;
@@ -11,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/applications")
@@ -36,5 +39,13 @@ public class ApplicationController {
         SubmitApplicationResponse response = applicationService.submitApplication(jobId, cv, principal);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("Application submitted successfully", response));
+    }
+
+    /** GET /api/v1/applications/me — list current candidate's applications. */
+    @GetMapping("/me")
+    @IsCandidate
+    public ResponseEntity<ApiResponse<List<ApplicationResponse>>> listMyApplications(
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+        return ResponseEntity.ok(ApiResponse.success(applicationService.listMyApplications(principal.id())));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/controller/JobController.java
+++ b/backend/src/main/java/com/eaa/recruit/controller/JobController.java
@@ -3,7 +3,9 @@ package com.eaa.recruit.controller;
 import com.eaa.recruit.dto.ApiResponse;
 import com.eaa.recruit.dto.job.CreateJobRequest;
 import com.eaa.recruit.dto.job.CreateJobResponse;
+import com.eaa.recruit.dto.job.JobResponse;
 import com.eaa.recruit.security.AuthenticatedUser;
+import com.eaa.recruit.security.rbac.IsAuthenticated;
 import com.eaa.recruit.security.rbac.IsRecruiter;
 import com.eaa.recruit.service.JobService;
 import jakarta.validation.Valid;
@@ -12,9 +14,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/jobs")
-@IsRecruiter
 public class JobController {
 
     private final JobService jobService;
@@ -23,11 +26,8 @@ public class JobController {
         this.jobService = jobService;
     }
 
-    /**
-     * POST /api/v1/jobs
-     * Creates a new job posting in DRAFT status. Recruiter only.
-     */
     @PostMapping
+    @IsRecruiter
     public ResponseEntity<ApiResponse<CreateJobResponse>> createJob(
             @Valid @RequestBody CreateJobRequest request,
             @AuthenticationPrincipal AuthenticatedUser principal) {
@@ -35,5 +35,24 @@ public class JobController {
         CreateJobResponse response = jobService.createJob(request, principal);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("Job posting created successfully", response));
+    }
+
+    @GetMapping
+    @IsAuthenticated
+    public ResponseEntity<ApiResponse<List<JobResponse>>> listOpenJobs() {
+        return ResponseEntity.ok(ApiResponse.success(jobService.listOpenJobs()));
+    }
+
+    @GetMapping("/mine")
+    @IsRecruiter
+    public ResponseEntity<ApiResponse<List<JobResponse>>> listMyJobs(
+            @AuthenticationPrincipal AuthenticatedUser principal) {
+        return ResponseEntity.ok(ApiResponse.success(jobService.listJobsByRecruiter(principal.id())));
+    }
+
+    @GetMapping("/{id}")
+    @IsAuthenticated
+    public ResponseEntity<ApiResponse<JobResponse>> getJob(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.success(jobService.getJob(id)));
     }
 }

--- a/backend/src/main/java/com/eaa/recruit/dto/admin/AdminUserResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/admin/AdminUserResponse.java
@@ -1,0 +1,12 @@
+package com.eaa.recruit.dto.admin;
+
+import java.time.Instant;
+
+public record AdminUserResponse(
+        Long    id,
+        String  email,
+        String  fullName,
+        String  role,
+        boolean active,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/application/ApplicationResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/application/ApplicationResponse.java
@@ -1,0 +1,22 @@
+package com.eaa.recruit.dto.application;
+
+import com.eaa.recruit.entity.ApplicationStatus;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ApplicationResponse(
+        Long              id,
+        Long              jobId,
+        String            jobTitle,
+        String            candidateName,
+        ApplicationStatus status,
+        Double            cvRelevanceScore,
+        Double            examScore,
+        Boolean           hardFilterPassed,
+        Double            finalScore,
+        Instant           submittedAt,
+        LocalDate         interviewSlotDate,
+        LocalTime         interviewSlotTime
+) {}

--- a/backend/src/main/java/com/eaa/recruit/dto/job/JobResponse.java
+++ b/backend/src/main/java/com/eaa/recruit/dto/job/JobResponse.java
@@ -1,0 +1,18 @@
+package com.eaa.recruit.dto.job;
+
+import com.eaa.recruit.entity.JobPostingStatus;
+
+import java.time.LocalDate;
+
+public record JobResponse(
+        Long             id,
+        String           title,
+        String           description,
+        Integer          minHeightCm,
+        Integer          minWeightKg,
+        String           requiredDegree,
+        LocalDate        openDate,
+        LocalDate        closeDate,
+        LocalDate        examDate,
+        JobPostingStatus status
+) {}

--- a/backend/src/main/java/com/eaa/recruit/entity/JobPosting.java
+++ b/backend/src/main/java/com/eaa/recruit/entity/JobPosting.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
     name = "job_postings",
     indexes = {
         @Index(name = "idx_job_postings_status", columnList = "status"),
-        @Index(name = "idx_job_postings_created_by", columnList = "created_by")
+        @Index(name = "idx_job_postings_created_by", columnList = "created_by_id")
     }
 )
 public class JobPosting extends BaseEntity {
@@ -43,7 +43,7 @@ public class JobPosting extends BaseEntity {
     private JobPostingStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "created_by", nullable = false, updatable = false)
+    @JoinColumn(name = "created_by_id", nullable = false, updatable = false)
     private User createdBy;
 
     protected JobPosting() {}

--- a/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/ApplicationRepository.java
@@ -19,6 +19,8 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     Optional<Application> findByCandidateIdAndJobId(Long candidateId, Long jobId);
 
+    List<Application> findByCandidateIdOrderBySubmittedAtDesc(Long candidateId);
+
     List<Application> findByJobId(Long jobId);
 
     List<Application> findByJobIdAndStatus(Long jobId, ApplicationStatus status);

--- a/backend/src/main/java/com/eaa/recruit/repository/UserRepository.java
+++ b/backend/src/main/java/com/eaa/recruit/repository/UserRepository.java
@@ -5,6 +5,7 @@ import com.eaa.recruit.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     long countByRole(Role role);
+
+    List<User> findByRoleOrderByCreatedAtDesc(Role role);
+
+    List<User> findAllByOrderByCreatedAtDesc();
 }

--- a/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/ApplicationService.java
@@ -1,10 +1,12 @@
 package com.eaa.recruit.service;
 
 import com.eaa.recruit.dto.application.AiScoreCallbackRequest;
+import com.eaa.recruit.dto.application.ApplicationResponse;
 import com.eaa.recruit.dto.application.SubmitApplicationResponse;
 import com.eaa.recruit.dto.internal.ExamScoreCallbackRequest;
 import com.eaa.recruit.entity.Application;
 import com.eaa.recruit.entity.ApplicationStatus;
+import com.eaa.recruit.entity.AvailabilitySlot;
 import com.eaa.recruit.entity.JobPosting;
 import com.eaa.recruit.entity.JobPostingStatus;
 import com.eaa.recruit.entity.User;
@@ -22,6 +24,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 public class ApplicationService {
@@ -92,6 +96,33 @@ public class ApplicationService {
                 jobId,
                 application.getStatus(),
                 application.getSubmittedAt()
+        );
+    }
+
+    /** Candidate views their own applications, newest first. */
+    @Transactional(readOnly = true)
+    public List<ApplicationResponse> listMyApplications(Long candidateId) {
+        return applicationRepository.findByCandidateIdOrderBySubmittedAtDesc(candidateId)
+                .stream().map(ApplicationService::toResponse).toList();
+    }
+
+    private static ApplicationResponse toResponse(Application app) {
+        AvailabilitySlot slot = app.getInterviewSlot();
+        User candidate = app.getCandidate();
+        JobPosting job = app.getJob();
+        return new ApplicationResponse(
+                app.getId(),
+                job.getId(),
+                job.getTitle(),
+                candidate.getFullName(),
+                app.getStatus(),
+                app.getCvRelevanceScore(),
+                app.getExamScore(),
+                app.getHardFilterPassed(),
+                app.getFinalScore(),
+                app.getSubmittedAt(),
+                slot == null ? null : slot.getSlotDate(),
+                slot == null ? null : slot.getStartTime()
         );
     }
 

--- a/backend/src/main/java/com/eaa/recruit/service/JobService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/JobService.java
@@ -2,7 +2,9 @@ package com.eaa.recruit.service;
 
 import com.eaa.recruit.dto.job.CreateJobRequest;
 import com.eaa.recruit.dto.job.CreateJobResponse;
+import com.eaa.recruit.dto.job.JobResponse;
 import com.eaa.recruit.entity.JobPosting;
+import com.eaa.recruit.entity.JobPostingStatus;
 import com.eaa.recruit.entity.User;
 import com.eaa.recruit.exception.BusinessException;
 import com.eaa.recruit.exception.ResourceNotFoundException;
@@ -13,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 public class JobService {
@@ -57,6 +61,40 @@ public class JobService {
                 job.getOpenDate(),
                 job.getCloseDate(),
                 job.getExamDate()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<JobResponse> listOpenJobs() {
+        return jobPostingRepository.findByStatus(JobPostingStatus.OPEN)
+                .stream().map(JobService::toResponse).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<JobResponse> listJobsByRecruiter(Long recruiterId) {
+        return jobPostingRepository.findByCreatedById(recruiterId)
+                .stream().map(JobService::toResponse).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public JobResponse getJob(Long id) {
+        JobPosting job = jobPostingRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Job not found: " + id));
+        return toResponse(job);
+    }
+
+    private static JobResponse toResponse(JobPosting job) {
+        return new JobResponse(
+                job.getId(),
+                job.getTitle(),
+                job.getDescription(),
+                job.getMinHeightCm(),
+                job.getMinWeightKg(),
+                job.getRequiredDegree(),
+                job.getOpenDate(),
+                job.getCloseDate(),
+                job.getExamDate(),
+                job.getStatus()
         );
     }
 

--- a/backend/src/main/java/com/eaa/recruit/service/RecruiterAdminService.java
+++ b/backend/src/main/java/com/eaa/recruit/service/RecruiterAdminService.java
@@ -1,5 +1,6 @@
 package com.eaa.recruit.service;
 
+import com.eaa.recruit.dto.admin.AdminUserResponse;
 import com.eaa.recruit.dto.admin.CreateRecruiterRequest;
 import com.eaa.recruit.dto.admin.RecruiterCreatedResponse;
 import com.eaa.recruit.entity.Role;
@@ -12,6 +13,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 public class RecruiterAdminService {
@@ -54,5 +57,24 @@ public class RecruiterAdminService {
         return new RecruiterCreatedResponse(
                 recruiter.getId(), recruiter.getEmail(),
                 recruiter.getFullName(), "Recruiter account created successfully");
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminUserResponse> listUsers(Role roleFilter) {
+        List<User> users = (roleFilter == null)
+                ? userRepository.findAllByOrderByCreatedAtDesc()
+                : userRepository.findByRoleOrderByCreatedAtDesc(roleFilter);
+        return users.stream().map(RecruiterAdminService::toResponse).toList();
+    }
+
+    private static AdminUserResponse toResponse(User u) {
+        return new AdminUserResponse(
+                u.getId(),
+                u.getEmail(),
+                u.getFullName(),
+                u.getRole().name(),
+                u.isActive(),
+                u.getCreatedAt()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- New GET endpoints wired with the recently added DTOs:
  - `GET /api/v1/jobs` (open jobs, any auth) / `/mine` (recruiter) / `/{id}` (single)
  - `GET /api/v1/applications/me` (candidate's own, newest first)
  - `GET /api/v1/admin/users[?role=…]`
- Docker stack now boots end-to-end: drop JDK 23 toolchain to 21 (SB 3.2.5 incompatible with 23), add `flyway-core` so migrations actually run, mkdir+chown `/app/cv-uploads` and `/app/xai-reports` for the non-root `app` user.
- Fix `JobPosting.@JoinColumn` to `created_by_id` so JPA matches the V3 migration column.

## Test plan
- [x] `docker compose up -d --build` brings all 7 services up; `curl localhost:8080/actuator/health` → `{"status":"UP"}`
- [ ] Hit `GET /api/v1/jobs` as a candidate JWT — receives empty list (no published jobs in fresh DB)
- [ ] Recruiter creates job, then `GET /api/v1/jobs/mine` returns it
- [ ] Candidate submits application, then `GET /api/v1/applications/me` returns it with status SUBMITTED
- [ ] Admin hits `GET /api/v1/admin/users?role=RECRUITER` and sees only recruiter accounts